### PR TITLE
Fix parser

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -6,14 +6,14 @@ pub use display_config::DisplayConfig;
 pub use tree::repr_tree;
 
 use crate::recipe::{Language, Recipe};
-use crate::replacer::{ReplaceFmt, UnknownToken};
+use crate::replacer::{InvalidTokenStrategy, ReplaceFmt};
 
 use std::collections::HashMap;
 
 use colored::Colorize;
 
 const DELIMS: (&str, &str) = ("{", "}");
-const FALLBACK: UnknownToken = UnknownToken::Preserve;
+const FALLBACK: InvalidTokenStrategy = InvalidTokenStrategy::Preserve;
 
 /// Formats and displays a list of recipes according to a provided configuration.
 pub fn display_recipes_with_config(recipes: &[&Recipe], config: &DisplayConfig) -> String {

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -12,7 +12,7 @@ use crate::mkdev_error::{
     Error::{self, *},
     ResultExt,
 };
-use crate::replacer::{ReplaceFmt, UnknownToken};
+use crate::replacer::{InvalidTokenStrategy, ReplaceFmt};
 use crate::warning;
 
 use std::collections::HashMap;
@@ -71,7 +71,7 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
         })
         .collect();
 
-    let re = ReplaceFmt::new(user_subs, ("{{", "}}"), UnknownToken::Preserve);
+    let re = ReplaceFmt::new(user_subs, ("{{", "}}"), InvalidTokenStrategy::Preserve);
 
     // --- Build ---
     let extra_args = args.clone();

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -13,14 +13,14 @@ use std::collections::HashMap;
 pub struct ReplaceFmt {
     subs: HashMap<String, String>,
     delims: Delimiters,
-    strategy: UnknownToken,
+    strategy: InvalidTokenStrategy,
 }
 
 impl ReplaceFmt {
     pub fn new(
         subs: HashMap<String, String>,
         delims: (&str, &str),
-        fallback_strategy: UnknownToken,
+        fallback_strategy: InvalidTokenStrategy,
     ) -> Self {
         Self {
             subs,
@@ -63,14 +63,14 @@ impl ReplaceFmt {
                         Some(val) => resolver(val),
                         // Strategy-defined resolution for failed lookups.
                         None => match self.strategy {
-                            UnknownToken::PassThrough => Some(key),
-                            UnknownToken::Preserve => Some(format!(
+                            InvalidTokenStrategy::PassThrough => Some(key),
+                            InvalidTokenStrategy::Preserve => Some(format!(
                                 "{}{}{}",
                                 self.delims.open.iter().collect::<String>(),
                                 key,
                                 self.delims.close.iter().collect::<String>()
                             )),
-                            UnknownToken::Ignore => None,
+                            InvalidTokenStrategy::Ignore => None,
                         },
                     }
                 }
@@ -80,7 +80,12 @@ impl ReplaceFmt {
     }
 }
 
-/// A one-time use parser for a format string.
+/// A single-use parser for a format string.
+///
+/// Parses a `Vec<char>` into a `Vec<Segment>` for the `ReplaceFmt` struct to consume. The parser
+/// locates special "tokens" which are delimited by the provided delimiters. If an open delimiter
+/// is found with a leading backslash ('\'), it is ignored and treated as part of the current text
+/// segment.
 #[derive(Clone, Debug)]
 struct Parser {
     source: Vec<char>,
@@ -89,6 +94,7 @@ struct Parser {
 }
 
 impl Parser {
+    /// Parses out the the Tokens, consuming the parser.
     pub fn parse(mut self) -> Vec<Segment> {
         let mut out = vec![];
         while !self.at_end() {
@@ -97,6 +103,7 @@ impl Parser {
         out
     }
 
+    /// Yields the next contiguous segment from the source buffer.
     fn next_segment(&mut self) -> Segment {
         if self.has_open() {
             self.parse_token()
@@ -105,6 +112,7 @@ impl Parser {
         }
     }
 
+    /// Parses out a delimited token, returning the token name and consuming the delimiters.
     fn parse_token(&mut self) -> Segment {
         self.curr += self.delims.open.len();
         let mut buf = String::new();
@@ -130,6 +138,7 @@ impl Parser {
         }
     }
 
+    /// Parses out generic text until the first non-escaped open delimiter is found.
     fn parse_text(&mut self) -> Segment {
         let mut buf = String::new();
         while !self.has_open() && !self.at_end() {
@@ -149,16 +158,19 @@ impl Parser {
         Segment::Text(buf)
     }
 
+    /// Yields the character at the current place in the buffer and advances.
     fn advance(&mut self) -> char {
         let c = self.source[self.curr];
         self.curr += 1;
         c
     }
 
+    /// Returns `true` if the remainder of the buffer starts with an open delimiter.
     fn has_open(&self) -> bool {
         self.source[self.curr..].starts_with(&self.delims.open)
     }
 
+    /// Returns `true` if the remainder of the buffer starts with an escaped open delimiter.
     fn has_escaped_open(&self) -> bool {
         self.source[self.curr..].starts_with(&['\\'])
             && self
@@ -167,10 +179,15 @@ impl Parser {
                 .is_some_and(|s| s.starts_with(&self.delims.open))
     }
 
+    /// Returns `true` if the remainder of the buffer starts with a close delimiter.
     fn has_close(&self) -> bool {
         self.source[self.curr..].starts_with(&self.delims.close)
     }
 
+    /// Returns `true` if the buffer has been fully read.
+    ///
+    /// This is determined by checking if the buffer pointer has reached or exceeded the length of
+    /// the buffer.
     fn at_end(&self) -> bool {
         self.curr >= self.source.len()
     }
@@ -190,7 +207,7 @@ enum Segment {
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
-pub enum UnknownToken {
+pub enum InvalidTokenStrategy {
     /// Pass just the token name
     PassThrough,
     /// Pass the token name surrounded by its delimiters
@@ -201,10 +218,14 @@ pub enum UnknownToken {
 
 #[cfg(test)]
 mod tests {
-    use super::UnknownToken::*;
+    use super::InvalidTokenStrategy::*;
     use super::*;
 
-    fn make_fmt(subs: &[(&str, &str)], delims: (&str, &str), strat: UnknownToken) -> ReplaceFmt {
+    fn make_fmt(
+        subs: &[(&str, &str)],
+        delims: (&str, &str),
+        strat: InvalidTokenStrategy,
+    ) -> ReplaceFmt {
         ReplaceFmt::new(
             subs.iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -133,7 +133,18 @@ impl Parser {
     fn parse_text(&mut self) -> Segment {
         let mut buf = String::new();
         while !self.has_open() && !self.at_end() {
-            buf.push(self.advance());
+            // General case: pass characters through to buffer
+            if !self.has_escaped_open() {
+                buf.push(self.advance());
+                continue;
+            }
+
+            // Escaped delimiters: skip the \, pass the delimiters through
+            // untouched.
+            _ = self.advance();
+            for _ in 0..self.delims.open.len() {
+                buf.push(self.advance());
+            }
         }
         Segment::Text(buf)
     }
@@ -146,6 +157,14 @@ impl Parser {
 
     fn has_open(&self) -> bool {
         self.source[self.curr..].starts_with(&self.delims.open)
+    }
+
+    fn has_escaped_open(&self) -> bool {
+        self.source[self.curr..].starts_with(&['\\'])
+            && self
+                .source
+                .get(self.curr + 1..)
+                .is_some_and(|s| s.starts_with(&self.delims.open))
     }
 
     fn has_close(&self) -> bool {
@@ -254,5 +273,35 @@ mod tests {
     fn empty_token_treated_as_text() {
         let fmt = make_fmt(&[("", "oops")], ("{{", "}}"), Ignore);
         assert_eq!(fmt.replace("{{}}"), "{{}}");
+    }
+
+    #[test]
+    fn ignore_escaped_delimiter() {
+        let fmt = make_fmt(&[("a", "b")], ("{{", "}}"), Ignore);
+        assert_eq!(fmt.replace("\\{{a}}"), "{{a}}");
+    }
+
+    #[test]
+    fn regular_escapes_ignored() {
+        let fmt = make_fmt(&[("a", "b")], ("{{", "}}"), Ignore);
+        assert_eq!(fmt.replace("\\ {{a}}"), "\\ b");
+    }
+
+    #[test]
+    fn escaped_single_char_delimiter() {
+        let fmt = make_fmt(&[("a", "b")], ("{", "}"), Ignore);
+        assert_eq!(fmt.replace("\\{a}"), "{a}");
+    }
+
+    #[test]
+    fn trailing_backslash_does_not_panic() {
+        let fmt = make_fmt(&[("a", "b")], ("{{", "}}"), Ignore);
+        assert_eq!(fmt.replace("hello\\"), "hello\\");
+    }
+
+    #[test]
+    fn trailing_backslash_single_char_delimiter_does_not_panic() {
+        let fmt = make_fmt(&[("a", "b")], ("{", "}"), Ignore);
+        assert_eq!(fmt.replace("hello\\"), "hello\\");
     }
 }


### PR DESCRIPTION
This PR fixes a parity issue with the old parser by re-adding a way to escape tokens, and improves documentation/naming for some of the internal functions and structs.