### PR TITLE
Rework `mkdev_error::Error` and improve ergonomics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,6 @@ dependencies = [
  "ser_nix",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "toml 0.8.23",
 ]
 
@@ -705,7 +704,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -899,16 +898,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -916,17 +906,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,15 @@ path = "src/main.rs"
 clap = { version = "4.5.23", features = ["cargo", "derive"] }
 clap_complete = { version = "4.5.47", features = ["unstable-dynamic"] }
 clap_mangen = "0.2.26"
+colored = "3.0.0"
+confique = { version = "0.4.0", features = ["toml"] }
 dirs = "5.0.1"
 hyperpolyglot = "0.1.7"
+ignore = "0.4.23"
+ser_nix = "0.2.2"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.140"
-ser_nix = "0.2.2"
 toml = "0.8.19"
-thiserror = "2.0.12"
-colored = "3.0.0"
-ignore = "0.4.23"
-confique = { version = "0.4.0", features = ["toml"] }
 
 [profile.release]
 codegen-units = 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 //! mkdev's user configuration file.
+use crate::ctx;
 use crate::display::DisplayConfig;
 use crate::mkdev_error::{Error, ResultExt};
 
@@ -88,7 +89,7 @@ impl Config {
         if let Some(dir) = config_file.parent()
             && !dir.is_dir()
         {
-            fs::create_dir_all(dir).context("unable to create mkdev configuration directory")?;
+            ctx!(fs::create_dir_all(dir), "creating config directory")?;
         }
 
         if !config_file.is_file() {
@@ -96,13 +97,11 @@ impl Config {
             let serialized_default = toml::to_string(&cfg)
                 .expect("Default configuration should always serialize correctly");
 
-            fs::write(config_file, serialized_default)
-                .context("unable to write default configuration file")?;
+            ctx!(fs::write(config_file, serialized_default), "writing config")?;
 
             Ok(cfg)
         } else {
-            let cfg_contents =
-                fs::read_to_string(config_file).context("unable to read configuration file")?;
+            let cfg_contents = ctx!(fs::read_to_string(config_file), "reading config")?;
 
             let cfg: Config = toml::from_str(&cfg_contents).context("configuration file")?;
 

--- a/src/content.rs
+++ b/src/content.rs
@@ -2,8 +2,8 @@
 use ignore::overrides::OverrideBuilder;
 
 use crate::cli::Imprint;
+use crate::ctx;
 use crate::mkdev_error;
-use crate::mkdev_error::ResultExt;
 
 use std::cmp::Ordering;
 use std::fs;
@@ -106,7 +106,7 @@ pub fn make_contents(walk: Walk) -> io::Result<Vec<RecipeItem>> {
 ///
 /// This function exists to allow users to override the walk behaviour.
 pub fn build_walk(args: &Imprint) -> Result<Walk, mkdev_error::Error> {
-    let cwd = std::env::current_dir().context("could not build walk object")?;
+    let cwd = ctx!(std::env::current_dir(), "getting cwd")?;
 
     let mut ob = OverrideBuilder::new(&cwd);
     for over in &args.exclude {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,8 +1,8 @@
 //! Functions that are tangential to or mutually exclusive with recipe logic.
 use crate::cli::Cli;
 use crate::config::Config;
-use crate::mkdev_error::{Error, ResultExt};
-use crate::{die, warning};
+use crate::mkdev_error::Error;
+use crate::{ctx, die, warning};
 
 use std::fs::File;
 use std::io::BufWriter;
@@ -86,7 +86,7 @@ fn man(args: &Cli) -> Result<(), Error> {
         let command = Cli::command();
 
         let out_dir = Path::new("mkdev-man");
-        std::fs::create_dir_all(out_dir).context("unable to make directory for man pages")?;
+        ctx!(std::fs::create_dir_all(out_dir), "man-hook")?;
 
         // Get all commands as a Vec<Command>
         let to_render: Vec<(clap::Command, Option<&str>)> = vec![(command.clone(), None)]
@@ -115,13 +115,11 @@ fn man(args: &Cli) -> Result<(), Error> {
                 let path = out_dir.join(&filename);
 
                 // Create the file and open it for writing
-                let file =
-                    File::create(path).context(&format!("unable to create {}", &filename))?;
+                let file = ctx!(File::create(path), "man-hook")?;
                 let mut writer = BufWriter::new(file);
 
                 // Write the contents of the page into the file
-                man.render(&mut writer)
-                    .context(&format!("unable to write {}", &filename))?;
+                ctx!(man.render(&mut writer), "man-hook")?;
 
                 Ok(())
             })?;
@@ -184,15 +182,13 @@ fn man5() -> Result<(), Error> {
     ]);
 
     // Create the man page file.
-    let man5_file = File::create("mkdev-man/mkdev-config.5")
-        .context("unable to create mkdev-man/mkdev-config.5")?;
+    let man5_file = ctx!(File::create("mkdev-man/mkdev-config.5"), "man-hook")?;
 
     // Create a write buffer.
     let mut w = BufWriter::new(man5_file);
 
     // Render our manpage to it.
-    roff.to_writer(&mut w)
-        .context("unable to write to mkdev-man/mkdev-config.5")?;
+    ctx!(roff.to_writer(&mut w), "man-hook")?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ mod replacer;
 
 use cli::{Cli, Commands::*};
 use hooks::hooks;
-use mkdev_error::ResultExt;
 use recipe::Recipe;
 use recipe::{build_recipes, delete_recipe, imprint_recipe, list_recipe};
 
@@ -37,7 +36,7 @@ fn try_get_status(args: Cli) -> Result<(), mkdev_error::Error> {
     // recipe logic.
     hooks(&args)?;
 
-    let user_recipes = Recipe::gather().context("unable to load recipes")?;
+    let user_recipes = ctx!(Recipe::gather(), "loading recipes")?;
 
     match args.command {
         Some(command) => match command {

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -3,37 +3,83 @@
 use std::io;
 
 /// mkdev's error type.
-#[derive(thiserror::Error, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum Error {
     /// Indicates that something wasn't specified when it should be.
-    #[error("no {0} specified.")]
-    NoneSpecified(String),
+    NoneSpecified { subject: Subject },
 
     /// Indicates that a value is invalid in the context it was passed.
-    #[error("invalid {0}{examples}", examples = {
-        match .1 {
-            Some(eg) => format!(":\n{}", eg.join("\n")),
-            None => String::from("."),
-        }
-    })]
-    Invalid(String, Option<Vec<String>>),
-
-    /// Wraps `std::io::Error`.
-    #[error("{0}: {1}")]
-    Io(String, String),
-
-    /// Indicates that a value failed to serialise.
-    #[error("failed to serialise {0}: {1}")]
-    Serialisation(String, String),
-
-    /// Indicates that a value failed to deserialise.
-    #[allow(unused)]
-    #[error("failed to deserialise {0}: {1}")]
-    Deserialisation(String, String),
+    Invalid {
+        subject: Subject,
+        examples: Option<Vec<String>>,
+    },
 
     /// Indicates that an action would be destructive.
-    #[error("'{0}' already exists. Use -s to overwrite.")]
-    DestructionWarning(String),
+    DestructionWarning { name: String },
+
+    /// Wraps `std::io::Error`.
+    Io {
+        context: &'static str,
+        cause: String,
+    },
+
+    /// Indicates that a value failed to serialise.
+    Serialisation { what: &'static str, cause: String },
+
+    /// Indicates that a value failed to deserialise.
+    Deserialisation { what: &'static str, cause: String },
+}
+
+impl std::error::Error for Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: locale
+        match self {
+            Error::NoneSpecified { subject } => {
+                write!(f, "no {subject} specified.")
+            }
+            Error::Invalid { subject, examples } => {
+                let base = format!("invalid {subject}");
+                match examples.as_deref() {
+                    Some(eg) => {
+                        write!(f, "{base}:\n{}", eg.join("\n"))
+                    }
+                    None => {
+                        write!(f, "{base}")
+                    }
+                }
+            }
+            Error::DestructionWarning { name } => {
+                write!(f, "{name} already exists; use -s to overwrite")
+            }
+            Error::Io { context, cause } => {
+                write!(f, "{context}: {cause}")
+            }
+            Error::Serialisation { what, cause } => {
+                write!(f, "failed to serialise {what}: {cause}")
+            }
+            Error::Deserialisation { what, cause } => {
+                write!(f, "failed to serialise {what}: {cause}")
+            }
+        }
+    }
+}
+
+/// A subject for the Invalid and NoneSpecified error types.
+#[derive(Clone, Debug)]
+pub enum Subject {
+    Recipe,
+    Recipes,
+}
+
+impl std::fmt::Display for Subject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: locale
+        f.write_str(match self {
+            Self::Recipe => "recipe",
+            Self::Recipes => "recipes",
+        })
+    }
 }
 
 /// Print a warning to the stderr.
@@ -55,32 +101,59 @@ macro_rules! die {
     }};
 }
 
+/// A helper for providing debug info (file/line number) either on a raw error message or on a
+/// result that implements `ResultExt`.
+#[macro_export]
+macro_rules! ctx {
+    ($msg:literal) => {
+        concat!("[", file!(), ":", line!(), "] ", $msg)
+    };
+    ($res:expr, $msg:literal) => {{
+        use crate::mkdev_error::ResultExt;
+        ResultExt::context($res, ctx!($msg))
+    }};
+}
+
 /// Convert the error type of a result to `mkdev_error::Error`
 pub trait ResultExt<T> {
     /// Converts the `Result` using a context message.
-    fn context(self, s: &str) -> Result<T, Error>;
+    fn context(self, context: &'static str) -> Result<T, Error>;
 }
 
 impl<T> ResultExt<T> for Result<T, io::Error> {
-    fn context(self, s: &str) -> Result<T, Error> {
-        self.map_err(|e| Error::Io(s.to_string(), e.to_string()))
+    fn context(self, context: &'static str) -> Result<T, Error> {
+        self.map_err(|e| Error::Io {
+            context,
+            cause: e.to_string(),
+        })
     }
 }
 
 impl<T> ResultExt<T> for Result<T, ser_nix::Error> {
-    fn context(self, s: &str) -> Result<T, Error> {
-        self.map_err(|e| Error::Serialisation(s.to_string(), e.to_string()))
+    fn context(self, context: &'static str) -> Result<T, Error> {
+        self.map_err(|e| Error::Serialisation {
+            what: context,
+            cause: e.to_string(),
+        })
     }
 }
 
 impl<T> ResultExt<T> for Result<T, toml::de::Error> {
-    fn context(self, s: &str) -> Result<T, Error> {
-        self.map_err(|e| Error::Deserialisation(s.to_string(), e.message().to_string()))
+    fn context(self, context: &'static str) -> Result<T, Error> {
+        self.map_err(|e| Error::Deserialisation {
+            what: context,
+            cause: e.message().to_string(),
+        })
     }
 }
 
 impl From<ignore::Error> for Error {
     fn from(e: ignore::Error) -> Self {
-        Error::Io("error with exclude flags".into(), e.to_string())
+        // TODO: locale
+        let context = "error with exclude flags";
+        Error::Io {
+            context,
+            cause: e.to_string(),
+        }
     }
 }

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -109,7 +109,7 @@ macro_rules! ctx {
         concat!("[", file!(), ":", line!(), "] ", $msg)
     };
     ($res:expr, $msg:literal) => {{
-        use crate::mkdev_error::ResultExt;
+        use $crate::mkdev_error::ResultExt;
         ResultExt::context($res, ctx!($msg))
     }};
 }

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -3,9 +3,10 @@
 //! Used to delete recipes from their default location.
 use super::{Recipe, recipe_dir};
 use crate::cli::Delete;
+use crate::ctx;
 use crate::mkdev_error::{
     Error::{self, *},
-    ResultExt,
+    Subject,
 };
 
 use std::collections::HashMap;
@@ -19,15 +20,16 @@ pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Res
 
     match to_delete {
         Some(recipe) => {
-            let deleted_file = recipe
-                .delete()
-                .context(&format!("unable to delete `{}`", recipe.name))?;
+            let deleted_file = ctx!(recipe.delete(), "deleting recipe")?;
 
             println!("Deleted recipe at {}.", &deleted_file.display());
 
             Ok(())
         }
-        None => Err(Invalid("recipe".into(), Some(vec![args.recipe]))),
+        None => Err(Invalid {
+            subject: Subject::Recipe,
+            examples: Some(vec![args.recipe]),
+        }),
     }
 }
 

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -10,10 +10,10 @@ use crate::config::Config;
 use crate::content::RecipeItem;
 use crate::mkdev_error::{
     Error::{self, *},
-    ResultExt,
+    Subject,
 };
 use crate::replacer::{InvalidTokenStrategy, ReplaceFmt};
-use crate::warning;
+use crate::{ctx, warning};
 
 use std::collections::HashMap;
 use std::env::current_dir;
@@ -27,7 +27,9 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
     // --- Error handling ---
     // There is an error if no recipes are provided
     if args.recipes.is_empty() {
-        return Err(NoneSpecified("recipes".into()));
+        return Err(NoneSpecified {
+            subject: Subject::Recipes,
+        });
     }
 
     let non_existant_recipes: Vec<String> = args
@@ -44,7 +46,15 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
 
     // There is an error if there are any non-existent recipes specified by the user
     if !non_existant_recipes.is_empty() {
-        return Err(Invalid("recipe(s)".into(), Some(non_existant_recipes)));
+        let subject = match non_existant_recipes.len() {
+            1 => Subject::Recipe,
+            2.. => Subject::Recipes,
+            _ => unreachable!(),
+        };
+        return Err(Invalid {
+            subject,
+            examples: Some(non_existant_recipes),
+        });
     }
 
     // --- Replacer setup ---
@@ -56,7 +66,7 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
     // Build to the cwd, or a directory specified by the user
     let dir = match &args.dir_name {
         Some(dir) => PathBuf::from(dir),
-        None => current_dir().context("unable to get cwd")?,
+        None => ctx!(current_dir(), "getting cwd")?,
     };
 
     let user_subs: HashMap<_, _> = Config::get()?
@@ -81,8 +91,11 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
             .expect("Invalid recipes should have been filtered out.");
 
         // Context for failure, should building fail
-        let context = format!("unable to write `{}` to `{}`", recipe.name, dir.display());
-        build(&dir, &recipe.contents, &extra_args, &re).context(&context)
+        ctx!(
+            build(&dir, &recipe.contents, &extra_args, &re),
+            "evoking recipe(s)"
+        )
+        .inspect_err(|_| warning!("unable to evoke `{}` in '{}'", recipe.name, dir.display()))
     })
 }
 

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -7,6 +7,7 @@
 use super::{Language, Recipe, recipe_dir};
 use crate::cli::Imprint;
 use crate::content::{build_walk, make_contents};
+use crate::ctx;
 use crate::mkdev_error::{
     Error::{self, *},
     ResultExt,
@@ -23,13 +24,15 @@ use ignore::Walk;
 /// Imprints a recipe using arguments from the command line, and post processes it accordingly.
 pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     let walker = build_walk(&args)?;
-    let new = Recipe::imprint(args.recipe, args.description, walker)
-        .context("unable to read current_working directory for the recipe")?;
+    let new = ctx!(
+        Recipe::imprint(args.recipe, args.description, walker),
+        "imprinting recipe"
+    )?;
 
     if let Some(path) = args.to_nix {
         let nix_expression = ser_nix::to_string(&new).context("recipe")?;
 
-        fs::write(path, nix_expression).context("unable to write to output file")?;
+        ctx!(fs::write(path, nix_expression), "writing nix file")?;
 
         return Ok(());
     }
@@ -37,10 +40,10 @@ pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> R
     let destructive = user_recipes.iter().any(|(recipe, _)| recipe == &new.name);
 
     if destructive && !args.suppress_warnings {
-        return Err(DestructionWarning(new.name));
+        return Err(DestructionWarning { name: new.name });
     }
 
-    let save_location = new.save().context("Unable to save instantiated recipe")?;
+    let save_location = ctx!(new.save(), "saving recipe file")?;
 
     println!("{}", &save_location.display());
 

--- a/src/recipe/list.rs
+++ b/src/recipe/list.rs
@@ -5,7 +5,10 @@ use super::Recipe;
 use crate::cli::List;
 use crate::config::Config;
 use crate::display::{display_recipes_with_config, repr_tree};
-use crate::mkdev_error::Error::{self, *};
+use crate::mkdev_error::{
+    Error::{self, *},
+    Subject,
+};
 use crate::output_type::OutputType::{self, *};
 use crate::warning;
 
@@ -19,9 +22,10 @@ pub fn list_recipe(args: List, user_recipes: HashMap<String, Recipe>) -> Result<
 
     match args.recipe {
         Some(recipe) => {
-            let recipe = user_recipes
-                .get(recipe.as_str())
-                .ok_or_else(|| Invalid("recipe".into(), Some(vec![recipe])))?;
+            let recipe = user_recipes.get(recipe.as_str()).ok_or_else(|| Invalid {
+                subject: Subject::Recipe,
+                examples: Some(vec![recipe]),
+            })?;
 
             display_one(recipe, output_type);
         }
@@ -36,10 +40,14 @@ pub fn list_recipe(args: List, user_recipes: HashMap<String, Recipe>) -> Result<
     Ok(())
 }
 
+const SER_EXISTING_RECIPE: &str = //.
+    "Invalid recipes are filtered out by this point, \
+     and if they deserialised, they'll serialise back.";
+
 /// Displays all recipes.
 fn display_all(recipes: Vec<&Recipe>, output_type: OutputType, show_description: bool) {
     if let Toml = output_type {
-        warning!("option \"TOML\" invalid for displaying multiple recipes. ");
+        warning!("option \"TOML\" invalid for displaying multiple recipes.");
         return;
     }
 
@@ -58,13 +66,11 @@ fn display_all(recipes: Vec<&Recipe>, output_type: OutputType, show_description:
         Plain => recipes.iter().for_each(|r| println!("{}", r.name)),
         Json => println!(
             "{}",
-            serde_json::to_string_pretty(&recipes)
-                .expect("Recipes are instantiated with serde, and should unwrap")
+            serde_json::to_string_pretty(&recipes).expect(SER_EXISTING_RECIPE)
         ),
         Nix => println!(
             "{}",
-            ser_nix::to_string(&recipes)
-                .expect("Recipes are instantiated with serde, and should unwrap")
+            ser_nix::to_string(&recipes).expect(SER_EXISTING_RECIPE)
         ),
         _ => unreachable!(),
     }
@@ -77,18 +83,15 @@ fn display_one(recipe: &Recipe, output_type: OutputType) {
         Plain => print!("{}", recipe.display_contents_plain()),
         Json => println!(
             "{}",
-            serde_json::to_string_pretty(recipe)
-                .expect("Recipes are instantiated with serde, and should unwrap")
+            serde_json::to_string_pretty(recipe).expect(SER_EXISTING_RECIPE)
         ),
         Toml => println!(
             "{}",
-            toml::to_string_pretty(recipe)
-                .expect("Recipes are instantiated with serde, and should unwrap")
+            toml::to_string_pretty(recipe).expect(SER_EXISTING_RECIPE)
         ),
         Nix => println!(
             "{}",
-            ser_nix::to_string(&recipe)
-                .expect("Recipes are instantiated with serde, and should unwrap")
+            ser_nix::to_string(&recipe).expect(SER_EXISTING_RECIPE)
         ),
     }
 }


### PR DESCRIPTION
Changes
---
- Rework the variants of the `Error` enum to be structured variants instead of tuple variants.
- Add `ctx!()` macro that either adds line number context to a string literal or, when applied to `impl ResultExt<T>`, applies it to the provided context.
- Drop thiserror

This PR lays the groundwork for the coming localisation support. 