### PR TITLE
Add basic localisation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
 
 [[package]]
 name = "bitflags"
@@ -283,6 +298,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +366,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -390,7 +428,7 @@ dependencies = [
  "polyglot_tokenizer",
  "regex",
  "serde",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "termcolor",
 ]
 
@@ -444,6 +482,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -512,10 +559,21 @@ dependencies = [
  "dirs",
  "hyperpolyglot",
  "ignore",
+ "rust-i18n",
  "ser_nix",
  "serde",
  "serde_json",
+ "sys-locale",
  "toml 0.8.23",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -527,6 +585,12 @@ dependencies = [
  "hermit-abi 0.5.2",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -597,7 +661,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -743,6 +807,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
 
 [[package]]
+name = "rust-i18n"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+dependencies = [
+ "globwalk",
+ "once_cell",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+dependencies = [
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "syn",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools",
+ "lazy_static",
+ "normpath",
+ "once_cell",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "siphasher 1.0.2",
+ "toml 0.8.23",
+ "triomphe",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +964,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +987,24 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -872,6 +1027,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -993,6 +1157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1178,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,11 @@ confique = { version = "0.4.0", features = ["toml"] }
 dirs = "5.0.1"
 hyperpolyglot = "0.1.7"
 ignore = "0.4.23"
+rust-i18n = "3.1.5"
 ser_nix = "0.2.2"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.140"
+sys-locale = "0.3.2"
 toml = "0.8.19"
 
 [profile.release]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=locales/");
+}

--- a/locales/en-GB.toml
+++ b/locales/en-GB.toml
@@ -1,0 +1,5 @@
+_version = 1
+
+[errors]
+serialise = "failed to serialise %{what}: %{cause}"
+deserialise = "failed to deserialise %{what}: %{cause}"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,0 +1,12 @@
+_version = 1
+
+[errors]
+none_specified = "no %{subject} specified"
+invalid = "invalid %{subject}"
+destruction = "%{name} already exists; use -s to overwrite"
+serialise = "failed to serialize %{what}: %{cause}"
+deserialise = "failed to deserialize %{what}: %{cause}"
+
+[subject]
+recipe = "recipe"
+recipes = "recipes"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,12 +1,22 @@
 _version = 1
 
+[subject]
+recipe = "recipe"
+recipes = "recipes"
+
+[recipes]
+delete_msg = "Deleted recipe at %{path}."
+
 [errors]
 none_specified = "no %{subject} specified"
 invalid = "invalid %{subject}"
 destruction = "%{name} already exists; use -s to overwrite"
 serialise = "failed to serialize %{what}: %{cause}"
 deserialise = "failed to deserialize %{what}: %{cause}"
+evoke = "unable to evoke `%{recipe}` in '%{target}'"
+extant = "'%{subject}' already exists"
+toml_all = "displaying all recipes as TOML is unsupported."
 
-[subject]
-recipe = "recipe"
-recipes = "recipes"
+[warnings]
+child_failed = "could not run command '%{child}'"
+invalid_recipe = "the recipe located at %{path} is improperly formatted"

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,12 +54,10 @@ impl Config {
     pub fn get() -> Result<&'static Config, Error> {
         if CONFIG.get().is_none() {
             let config = Config::load()?;
-            CONFIG
-                .set(config)
-                .expect("This block only happens if it is not set.");
+            CONFIG.set(config).unwrap_or_else(|_| unreachable!());
         }
 
-        Ok(CONFIG.get().expect("Should be set"))
+        Ok(CONFIG.get().unwrap())
     }
 
     /// Override the default config path.
@@ -68,7 +66,7 @@ impl Config {
     pub fn override_path(path: PathBuf) {
         CONFIG_PATH_OVERRIDE
             .set(path)
-            .expect("Config override already set.");
+            .expect("double initiaisation of config path override");
     }
 
     /// Private api for loading the config if it is not already loaded.
@@ -80,7 +78,7 @@ impl Config {
         let config_file = match CONFIG_PATH_OVERRIDE.get() {
             Some(path) => path.clone(),
             None => dirs::config_dir()
-                .expect("This is generally infallible")
+                .expect("$HOME is not set; cannot determine config directory.")
                 .join("mkdev")
                 .join("config.toml"),
         };
@@ -94,8 +92,8 @@ impl Config {
 
         if !config_file.is_file() {
             let cfg = Config::default();
-            let serialized_default = toml::to_string(&cfg)
-                .expect("Default configuration should always serialize correctly");
+            let serialized_default =
+                toml::to_string(&cfg).expect("default `Config` is always serialisable.");
 
             ctx!(fs::write(config_file, serialized_default), "writing config")?;
 

--- a/src/content.rs
+++ b/src/content.rs
@@ -73,14 +73,14 @@ pub fn make_contents(walk: Walk) -> io::Result<Vec<RecipeItem>> {
 
         let data = file
             .file_type()
-            .expect("This can only be `None` if this is stdin, which is not allowed");
+            .expect("only none for stdin, which is not allowed.");
 
         let mut path = file.into_path();
 
         if path.starts_with(&cwd) {
             path = path
                 .strip_prefix(&cwd)
-                .expect("This is checked with `starts_with`")
+                .expect("prefix is confirmed to exist")
                 .into();
         }
 

--- a/src/hooks/cfg.rs
+++ b/src/hooks/cfg.rs
@@ -51,7 +51,7 @@ fn print_config() {
 /// Can be used to reset user config to default.
 fn print_default_config() {
     let config_str = toml::to_string_pretty(&Config::default())
-        .expect("Default configuration should alway serialise.");
+        .expect("default `Config` is always serialisable.");
 
     print!("{config_str}");
 }

--- a/src/hooks/cfg.rs
+++ b/src/hooks/cfg.rs
@@ -1,0 +1,57 @@
+//! Hook that does basic config operations such as printing, overrides, etc.
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::{die, warning};
+
+/// Handles operations that modify or pertain to mkdev's config file.
+///
+/// The print operations cause the program to exit early.
+pub fn hook(args: &Cli) {
+    let skip_main_logic = [args.gen_config, args.print_config].iter().any(|f| *f);
+    let commands_present = args.command.is_some();
+
+    if skip_main_logic && commands_present {
+        warning!("subcommand suppressed by one or more flags.");
+    }
+
+    if args.gen_config {
+        print_default_config();
+    }
+
+    if let Some(path) = args.config.clone() {
+        Config::override_path(path);
+    }
+
+    if args.print_config {
+        print_config();
+    }
+
+    if skip_main_logic {
+        std::process::exit(0);
+    }
+}
+
+/// Deserialises and prints the user's current config.
+fn print_config() {
+    let config = match Config::get() {
+        Ok(config) => config,
+        Err(why) => die!("could not get config: {}", why),
+    };
+
+    let config = match toml::to_string_pretty(&config) {
+        Ok(cfg) => cfg,
+        Err(_) => die!("improperly formatted configuration file."),
+    };
+
+    print!("{config}");
+}
+
+/// Prints the default config to stdout.
+///
+/// Can be used to reset user config to default.
+fn print_default_config() {
+    let config_str = toml::to_string_pretty(&Config::default())
+        .expect("Default configuration should alway serialise.");
+
+    print!("{config_str}");
+}

--- a/src/hooks/i18n.rs
+++ b/src/hooks/i18n.rs
@@ -1,0 +1,10 @@
+//! A hook that sets up internationalisation for mkdev.
+use rust_i18n::{available_locales, set_locale};
+use sys_locale::get_locales as preferred_locales;
+
+pub fn hook() {
+    // TODO: properly select locale by finding the first preferred that is available.
+    let preferred = preferred_locales().next().unwrap();
+
+    set_locale(&preferred);
+}

--- a/src/hooks/i18n.rs
+++ b/src/hooks/i18n.rs
@@ -1,10 +1,26 @@
 //! A hook that sets up internationalisation for mkdev.
+use std::collections::HashSet;
+
 use rust_i18n::{available_locales, set_locale};
 use sys_locale::get_locales as preferred_locales;
 
 pub fn hook() {
-    // TODO: properly select locale by finding the first preferred that is available.
-    let preferred = preferred_locales().next().unwrap();
+    let supported: HashSet<&str> = HashSet::from_iter(available_locales!());
+
+    let preferred = preferred_locales()
+        .map(|pref| normalise_locale(pref.as_str()))
+        .find(|pref| {
+            let base = pref.split(['-', '_']).next().unwrap_or(pref);
+            supported.contains(pref.as_str()) || supported.contains(base)
+        })
+        .unwrap_or("en-US".to_string());
 
     set_locale(&preferred);
+}
+
+fn normalise_locale(locale: &str) -> String {
+    locale
+        .split_once(['-', '_'])
+        .map(|(lang, region)| format!("{}-{}", lang.to_lowercase(), region.to_uppercase()))
+        .unwrap_or_else(|| locale.to_lowercase())
 }

--- a/src/hooks/man.rs
+++ b/src/hooks/man.rs
@@ -1,8 +1,11 @@
-//! Functions that are tangential to or mutually exclusive with recipe logic.
+//! A hook that generates man pages for mkdev.
+//!
+//! Generates a page in section 1 for each subcommand as well as a page in section 5 that describes
+//! the config struct.
 use crate::cli::Cli;
 use crate::config::Config;
+use crate::ctx;
 use crate::mkdev_error::Error;
-use crate::{ctx, die, warning};
 
 use std::fs::File;
 use std::io::BufWriter;
@@ -14,73 +17,8 @@ use clap_mangen::Man;
 use clap_mangen::roff::{Roff, bold, roman};
 use confique::meta::Meta;
 
-/// Calls every mkdev hook sequentially.
-pub fn hooks(args: &Cli) -> Result<(), Error> {
-    config(args);
-    man(args)?;
-
-    Ok(())
-}
-
-// --- Config Hook ---
-
-/// Handles operations that modify or pertain to mkdev's config file.
-///
-/// The print operations cause the program to exit early.
-fn config(args: &Cli) {
-    let skip_main_logic = [args.gen_config, args.print_config].iter().any(|f| *f);
-    let commands_present = args.command.is_some();
-
-    if skip_main_logic && commands_present {
-        warning!("subcommand suppressed by one or more flags.");
-    }
-
-    if args.gen_config {
-        print_default_config();
-    }
-
-    if let Some(path) = args.config.clone() {
-        Config::override_path(path);
-    }
-
-    if args.print_config {
-        print_config();
-    }
-
-    if skip_main_logic {
-        std::process::exit(0);
-    }
-}
-
-/// Deserialises and prints the user's current config.
-fn print_config() {
-    let config = match Config::get() {
-        Ok(config) => config,
-        Err(why) => die!("could not get config: {}", why),
-    };
-
-    let config = match toml::to_string_pretty(&config) {
-        Ok(cfg) => cfg,
-        Err(_) => die!("improperly formatted configuration file."),
-    };
-
-    print!("{config}");
-}
-
-/// Prints the default config to stdout.
-///
-/// Can be used to reset user config to default.
-fn print_default_config() {
-    let config_str = toml::to_string_pretty(&Config::default())
-        .expect("Default configuration should alway serialise.");
-
-    print!("{config_str}");
-}
-
-// --- Manpage Hook ---
-
 /// Generates all of mkdev's man pages and saves them to './mkdev-man'.
-fn man(args: &Cli) -> Result<(), Error> {
+pub fn hook(args: &Cli) -> Result<(), Error> {
     // if args.man_page {
     if args.man_page {
         let command = Cli::command();

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,22 @@
+//! Functions that are tangential to or mutually exclusive with recipe logic.
+mod cfg;
+mod i18n;
+mod man;
+
+use crate::cli::Cli;
+use crate::mkdev_error::Error;
+
+/// Calls every mkdev hook sequentially.
+pub fn hooks(args: &Cli) -> Result<(), Error> {
+    // mkdev configuration overrides
+    cfg::hook(args);
+
+    // man generation
+    // note: always exits program.
+    man::hook(args)?;
+
+    // locale selection
+    i18n::hook();
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use recipe::{build_recipes, delete_recipe, imprint_recipe, list_recipe};
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 
+rust_i18n::i18n!("locales", fallback = "en");
+
 fn main() {
     // Produce completion scripts using clap_complete...
     // note: this cannot be included in hooks because it must happen before parsing the command

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -1,7 +1,8 @@
 //! Implementats a unified error type, a unified logging interface, and conversions from common
 //! error types.
-use rust_i18n::t;
 use std::io;
+
+use rust_i18n::t;
 
 /// mkdev's error type.
 #[derive(Clone, Debug)]

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -1,5 +1,6 @@
 //! Implementats a unified error type, a unified logging interface, and conversions from common
 //! error types.
+use rust_i18n::t;
 use std::io;
 
 /// mkdev's error type.
@@ -33,16 +34,20 @@ pub enum Error {
 impl std::error::Error for Error {}
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: locale
         match self {
             Error::NoneSpecified { subject } => {
-                write!(f, "no {subject} specified.")
+                write!(f, "{}", t!("errors.none_specified", subject => subject))
             }
             Error::Invalid { subject, examples } => {
-                let base = format!("invalid {subject}");
+                let base = t!("errors.invalid", subject => subject);
                 match examples.as_deref() {
                     Some(eg) => {
-                        write!(f, "{base}:\n{}", eg.join("\n"))
+                        write!(
+                            f,
+                            "{base}:{}{}",
+                            if eg.len() > 1 { "\n" } else { " " },
+                            eg.join("\n")
+                        )
                     }
                     None => {
                         write!(f, "{base}")
@@ -50,16 +55,24 @@ impl std::fmt::Display for Error {
                 }
             }
             Error::DestructionWarning { name } => {
-                write!(f, "{name} already exists; use -s to overwrite")
+                write!(f, "{}", t!("errors.destruction", name => name))
             }
             Error::Io { context, cause } => {
                 write!(f, "{context}: {cause}")
             }
             Error::Serialisation { what, cause } => {
-                write!(f, "failed to serialise {what}: {cause}")
+                write!(
+                    f,
+                    "{}",
+                    t!("errors.serialise", what => what, cause => cause)
+                )
             }
             Error::Deserialisation { what, cause } => {
-                write!(f, "failed to serialise {what}: {cause}")
+                write!(
+                    f,
+                    "{}",
+                    t!("errors.deserialise", what => what, cause => cause)
+                )
             }
         }
     }
@@ -74,11 +87,14 @@ pub enum Subject {
 
 impl std::fmt::Display for Subject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: locale
-        f.write_str(match self {
-            Self::Recipe => "recipe",
-            Self::Recipes => "recipes",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Recipe => t!("subject.recipe"),
+                Self::Recipes => t!("subject.recipes"),
+            }
+        )
     }
 }
 
@@ -149,8 +165,7 @@ impl<T> ResultExt<T> for Result<T, toml::de::Error> {
 
 impl From<ignore::Error> for Error {
     fn from(e: ignore::Error) -> Self {
-        // TODO: locale
-        let context = "error with exclude flags";
+        let context = "exclude flags";
         Error::Io {
             context,
             cause: e.to_string(),

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -14,6 +14,8 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
+use rust_i18n::t;
+
 /// Deletes a recipe based on command line arguments.
 pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     let to_delete = user_recipes.get(args.recipe.as_str());
@@ -22,7 +24,10 @@ pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Res
         Some(recipe) => {
             let deleted_file = ctx!(recipe.delete(), "deleting recipe")?;
 
-            println!("Deleted recipe at {}.", &deleted_file.display());
+            println!(
+                "{}",
+                t!("recipes.delete_msg", path => &deleted_file.display())
+            );
 
             Ok(())
         }

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -22,6 +22,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use rust_i18n::t;
+
 /// Evokes a recipe according to arguments from the command line.
 pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     // --- Error handling ---
@@ -86,16 +88,19 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
     // --- Build ---
     let extra_args = args.clone();
     args.recipes.iter().try_for_each(|r| {
-        let recipe = user_recipes
-            .get(r)
-            .expect("Invalid recipes should have been filtered out.");
+        let recipe = user_recipes.get(r).expect("recipes were validated above.");
 
         // Context for failure, should building fail
         ctx!(
             build(&dir, &recipe.contents, &extra_args, &re),
             "evoking recipe(s)"
         )
-        .inspect_err(|_| warning!("unable to evoke `{}` in '{}'", recipe.name, dir.display()))
+        .inspect_err(|_| {
+            warning!(
+                "{}",
+                t!("errors.evoke", name => recipe.name, target => dir.display())
+            )
+        })
     })
 }
 
@@ -131,7 +136,7 @@ fn build(
                     use std::io::ErrorKind::*;
                     return Err(io::Error::new(
                         AlreadyExists,
-                        format!("'{}' already exists.", file.name.display()),
+                        format!("{}", t!("errors.extant", subject => file.name.display())),
                     ));
                 }
 
@@ -186,7 +191,7 @@ fn run_shell(cmd: &str) -> Option<String> {
             Some(stdout)
         }
         None => {
-            warning!("could not run command '{}'", cmd);
+            warning!("{}", t!("warnings.child_failed", child => cmd));
             None
         }
     }

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -71,7 +71,7 @@ impl Recipe {
             // Discard the count, as we only needed it to sort
             .map(|(lang, _)| {
                 hyperpolyglot::Language::try_from(*lang)
-                    .expect("Languages from `get_language_breakdown` are guaranteed")
+                    .expect("detected language come pre-validated.")
             })
             .map(Language::from)
             .collect();

--- a/src/recipe/list.rs
+++ b/src/recipe/list.rs
@@ -4,22 +4,24 @@
 use super::Recipe;
 use crate::cli::List;
 use crate::config::Config;
+use crate::die;
 use crate::display::{display_recipes_with_config, repr_tree};
 use crate::mkdev_error::{
     Error::{self, *},
     Subject,
 };
 use crate::output_type::OutputType::{self, *};
-use crate::warning;
 
 use std::collections::HashMap;
 
 use colored::Colorize;
+use rust_i18n::t;
 
 /// List a recipe/recipes in accordance to the provide command line arguments.
 pub fn list_recipe(args: List, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     let output_type = args.r#type.unwrap_or_default();
 
+    // TODO: allow displaying "all" recipes individually instead of a collection.
     match args.recipe {
         Some(recipe) => {
             let recipe = user_recipes.get(recipe.as_str()).ok_or_else(|| Invalid {
@@ -46,9 +48,9 @@ const SER_EXISTING_RECIPE: &str = //.
 
 /// Displays all recipes.
 fn display_all(recipes: Vec<&Recipe>, output_type: OutputType, show_description: bool) {
+    // TODO: allow displaying "all" recipes individually instead of a collection.
     if let Toml = output_type {
-        warning!("option \"TOML\" invalid for displaying multiple recipes.");
-        return;
+        die!("{}", t!("errors.toml_all"));
     }
 
     let mut config = Config::get()

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -24,6 +24,7 @@ use std::io;
 use std::path::PathBuf;
 
 use dirs::data_dir;
+use rust_i18n::t;
 use serde::{Deserialize, Serialize};
 
 /// A mkdev recipe (v2).
@@ -64,7 +65,7 @@ impl Recipe {
                         recipes.push(recipe);
                     }
                     None => {
-                        warning!("{} is not a valid recipe.", path.display());
+                        warning!("{}", t!("warnings.invalid_recipe", path => path.display()));
                     }
                 }
             }
@@ -89,11 +90,10 @@ pub fn recipe_dir() -> io::Result<PathBuf> {
         }
     };
 
-    let err = io::Error::other("Error getting data directory");
     let data_dir = match &cfg.recipe_dir {
         Some(dir) => dir.clone(),
         None => {
-            let mut temp = data_dir().ok_or(err)?;
+            let mut temp = data_dir().expect("$HOME is not set; cannot determine data directory.");
             temp.push("mkdev");
             temp
         }


### PR DESCRIPTION
This PR adds basic support for localisation:
- Detect the users preferred locale settings using `sys-locale`
- Display all warnings and most errors based on the locale

Additionally, a few error messages have been touched up for the English locale in the process.

Caveats:
- Due to the reliance on `&'static str`s in #13, the context messages for the `Io`, and `{Des, S}erialisation` types cannot be localised. This will be fixed by reworking the types and replacing them with more specific, semantic error types
- No additional languages are supported yet, but a distinction between `en_US` and `en_GB` is made so as to no longer force others to use my preferred "-ise" endings if they don't want to. Additional work is potentially needed for other English varieties.
- Nothing in the clap ecosystem is yet localised, and I'm uncertain if I will be able to in future PRs.