### PR TITLE
Interactive Imprinting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,10 +150,10 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.14",
  "vec_map",
 ]
 
@@ -252,6 +258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +292,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +362,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +389,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
 
 [[package]]
 name = "getrandom"
@@ -374,7 +478,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -469,6 +573,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "tempfile",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "is_executable"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +655,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +686,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "mkdev"
@@ -559,11 +711,13 @@ dependencies = [
  "dirs",
  "hyperpolyglot",
  "ignore",
+ "inquire",
  "rust-i18n",
  "ser_nix",
  "serde",
  "serde_json",
  "sys-locale",
+ "tempfile",
  "toml 0.8.23",
 ]
 
@@ -603,6 +757,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pcre2"
@@ -761,6 +938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1047,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +1088,18 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "ser_nix"
@@ -983,6 +1203,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1290,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +1317,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1074,6 +1338,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1174,10 +1447,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,13 @@ confique = { version = "0.4.0", features = ["toml"] }
 dirs = "5.0.1"
 hyperpolyglot = "0.1.7"
 ignore = "0.4.23"
+inquire = { version = "0.9.4", features = ["editor"] }
 rust-i18n = "3.1.5"
 ser_nix = "0.2.2"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.140"
 sys-locale = "0.3.2"
+tempfile = "3.27.0"
 toml = "0.8.19"
 
 [profile.release]

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,9 @@
       );
 
       overlays.default = prev: final: {
-          mkdev = prev.callPackage ./nix/mkdev.nix { };
-          mkf = prev.callPackage ./nix/mkf.nix { };
-        };
+        mkdev = prev.callPackage ./nix/mkdev.nix { };
+        mkf = prev.callPackage ./nix/mkf.nix { };
+      };
 
       homeManagerModules.default = import ./nix/home-manager.nix;
       homeManagerModule = # .
@@ -48,6 +48,7 @@
             clippy
             libgcc
             rustc
+            rustfmt
 
             # Nix
             statix

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,5 +1,13 @@
 _version = 1
 
+[general]
+# The word for yes and no, capitalised.
+yes = "Yes"
+no = "No"
+# The word for yes and no, lowercase and ASCII-only.
+yes_simple = "yes"
+no_simple  = "no"
+
 [subject]
 recipe = "recipe"
 recipes = "recipes"
@@ -11,9 +19,17 @@ evocation = "evoking recipe"
 gather = "gathering recipes"
 imprinting = "imprinting recipe"
 man = "generating man pages"
+tempfile = "creating temporary directory or file"
 
 [recipes]
 delete_msg = "Deleted recipe at %{path}."
+
+[menus]
+filter_rec = "Select which files to include. Press enter to confirm."
+get_desc = "Recipe Description:"
+get_name = "Recipe Name:"
+invalid_yn = "Invalid answer, try typing 'y' for yes or 'n' for no"
+recipe_overwrite = "This will overwrite the existing recipe '%{recipe}'. Are you sure?"
 
 [errors]
 deserialise = "deserialization error: could not deserialize data from %{which} (while %{context})"
@@ -24,9 +40,11 @@ fs_denied = "permission denied: could not access %{which} (while %{context})"
 invalid = "invalid %{subject}"
 no_cwd = "the current directory does not exist"
 none_specified = "no %{subject} specified"
+not_tty = "the input device is not a TTY"
 not_utf8 = "%{file} is not valid UTF-8"
 serialise = "serialization error: could not serialize data to %{which} (while %{context})"
 toml_all = "displaying all recipes as TOML simultaneously is unsupported"
+interrupted = "operation was interrupted"
 
 [warnings]
 child_failed = "could not run command '%{child}'"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -30,6 +30,9 @@ get_desc = "Recipe Description:"
 get_name = "Recipe Name:"
 invalid_yn = "Invalid answer, try typing 'y' for yes or 'n' for no"
 recipe_overwrite = "This will overwrite the existing recipe '%{recipe}'. Are you sure?"
+name_required = "A name for the recipe is required"
+selected_count = "%{count} files selected"
+multiselect_help = "↑↓ to move, space to select one, → to all, ← to none, type to filter"
 
 [errors]
 deserialise = "deserialization error: could not deserialize data from %{which} (while %{context})"

--- a/locales/es-AR.toml
+++ b/locales/es-AR.toml
@@ -1,0 +1,2 @@
+[menus]
+recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. ¿Seguro que querés sobrescribirla?"

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -1,5 +1,11 @@
 _version = 1
 
+[general]
+yes = "Sí"
+no = "No"
+yes_simple = "si"
+no_simple = "no"
+
 [subject]
 recipe = "receta"
 recipes = "recetas"
@@ -11,9 +17,17 @@ evocation = "evocar receta"
 gather = "recoger recetas"
 imprinting = "improntar receta"
 man = "generar páginas de manual"
+tempfile = "crear directorio o archivo temporal"
 
 [recipes]
 delete_msg = "Se eliminó la receta en %{path}."
+
+[menus]
+filter_rec = "Selecciona archivos para incluir. Presiona Enter para confirmar."
+get_desc = "Descripción de la Receta:"
+get_name = "Nombre de la Receta:"
+invalid_yn = "Respuesta inválida, intenta escribir 's' para sí o 'n' para no"
+recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. Estás seguro/a?"
 
 # WARN: this requires that subject.* and errors.invalid and
 # errors.none_specified agree. Currently they do, but nothing guarantees this
@@ -27,9 +41,11 @@ fs_denied = "permiso denegado: no se pudo acceder a %{which} (%{context})"
 invalid = "%{subject} inválida(s)"
 no_cwd = "el directorio de trabajo actual no existe"
 none_specified = "no se especificó ninguna(s) %{subject}"
+not_tty = "el dispositivo de entrada no es un teletipo"
 not_utf8 = "%{file} no contiene datos UTF-8 válidos"
 serialise = "error de serialización: no se pudo serializar datos a %{which} (%{context})"
 toml_all = "no es posible mostrar todas las recetas a la vez con el formato toml"
+interrupted = "la acción fue interrumpida"
 
 [warnings]
 child_failed = "no se pudo ejecutar el comando '%{child}'"

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -27,7 +27,10 @@ filter_rec = "Selecciona archivos para incluir. Presiona Enter para confirmar."
 get_desc = "Descripción de la Receta:"
 get_name = "Nombre de la Receta:"
 invalid_yn = "Respuesta inválida, intenta escribir 's' para sí o 'n' para no"
-recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. Estás seguro/a?"
+recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. ¿Seguro que quieres sobrescribirla?"
+name_required = "El nombre de la receta es obligatorio"
+selected_count = "%{count} archivos seleccionados"
+multiselect_help = "↑↓ para moverse, espacio para seleccionar uno, → para todos, ← para ninguno, escribe para filtrar"
 
 # WARN: this requires that subject.* and errors.invalid and
 # errors.none_specified agree. Currently they do, but nothing guarantees this

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,7 +87,12 @@ pub struct Evoke {
 #[derive(Parser, Debug)]
 pub struct Imprint {
     /// The name of the recipe to imprint.
+    #[arg(default_value = "", required_unless_present = "interactive")]
     pub recipe: String,
+
+    /// Create the recipe in interactive mode.
+    #[arg(short, long)]
+    pub interactive: bool,
 
     /// Description to be associated with recipe
     #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,10 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
 
+    /// Alias for `mk imprint --interactive`
+    #[arg(short, long)]
+    pub interactive: bool,
+
     /// Specify configuration file to load.
     #[arg(short, long, env = "CONFIG")]
     pub config: Option<PathBuf>,
@@ -84,7 +88,7 @@ pub struct Evoke {
     pub suppress_warnings: bool,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 pub struct Imprint {
     /// The name of the recipe to imprint.
     #[arg(default_value = "", required_unless_present = "interactive")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,13 @@ pub struct Config {
     /// Default:
     /// Absent (evaluates to ~/.local/share/mkdev on Linux)
     pub recipe_dir: Option<PathBuf>,
+    /// Whether multiselect prompts in interactive mode should allow for vim keybindings. Note that
+    /// this can make filtering more difficult (because h, j, k, and l will be reserved).
+    ///
+    /// Default:
+    /// false
+    #[serde(default = "default_vim")]
+    pub vim: bool,
     /// A mapping of key-value pairs used when building a recipe that defines what a token should
     /// evaluate to. For example, {{date}} => "date +%D".
     ///
@@ -132,14 +139,20 @@ fn default_subs() -> HashMap<String, String> {
     )
 }
 
+fn default_vim() -> bool {
+    false
+}
+
 impl Default for Config {
     fn default() -> Self {
         let recipe_dir = None;
+        let vim = default_vim();
         let subs = default_subs();
         let recipe_fmt = DisplayConfig::default();
 
         Self {
             recipe_dir,
+            vim,
             subs,
             recipe_fmt,
         }

--- a/src/content.rs
+++ b/src/content.rs
@@ -121,6 +121,12 @@ pub fn build_walk(args: &Imprint) -> Result<Walk, Error> {
         .build())
 }
 
+impl std::fmt::Display for RecipeItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 impl PartialEq for RecipeItem {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal

--- a/src/fs_wrappers.rs
+++ b/src/fs_wrappers.rs
@@ -1,3 +1,4 @@
+//! std::fs functions wrapped to return mkdev Errors instead of IO Errors.
 use crate::mkdev_error::{Context, Error};
 
 use std::fs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod content;
 mod display;
 mod fs_wrappers;
 mod hooks;
+mod menus;
 mod mkdev_error;
 mod output_type;
 mod recipe;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,14 @@ fn try_get_status(args: Cli) -> Result<(), mkdev_error::Error> {
             Delete(sub_args) => delete_recipe(sub_args, user_recipes),
             List(sub_args) => list_recipe(sub_args, user_recipes),
         },
+        None if args.interactive => {
+            let fake_args = cli::Imprint {
+                interactive: true,
+                ..Default::default()
+            };
+
+            imprint_recipe(fake_args, user_recipes)
+        }
         None => {
             // Print help and exit if no action is provided
             Cli::command().print_help().unwrap();

--- a/src/menus/locale.rs
+++ b/src/menus/locale.rs
@@ -1,0 +1,49 @@
+//! Provides locale-aware formatters and parsers to be used with interactive mode menus.
+use rust_i18n::t;
+
+/// Locale-aware boolean formatter for Inquire
+pub fn locale_bool_formatter(value: bool) -> String {
+    match value {
+        true => t!("general.yes").to_string(),
+        false => t!("general.no").to_string(),
+    }
+}
+
+/// Locale-aware default boolean ("y/N") formatter for Inquire.
+pub fn locale_bool_default_formatter(value: bool) -> String {
+    let (yes, no) = (&t!("general.yes_simple"), &t!("general.no_simple"));
+    let (mut y, mut n) = (first_char(yes), first_char(no));
+
+    match value {
+        true => y = y.to_uppercase().next().unwrap(),
+        false => n = n.to_uppercase().next().unwrap(),
+    }
+
+    format!("{y}/{n}")
+}
+
+/// Locale-aware boolean parser for Inquire.
+pub fn locale_bool_parser(input: &str) -> Result<bool, ()> {
+    let (yes, no) = (&t!("general.yes_simple"), &t!("general.no_simple"));
+
+    // Get &str of first character of yes and no
+    let y_c = first_char(yes);
+    let mut y_buf = [0u8; 4];
+    let y = y_c.encode_utf8(&mut y_buf);
+
+    let n_c = first_char(no);
+    let mut n_buf = [0u8; 4];
+    let n = n_c.encode_utf8(&mut n_buf);
+
+    match input {
+        input if input == yes => Ok(true),
+        input if input == no => Ok(false),
+        input if input == y => Ok(true),
+        input if input == n => Ok(false),
+        _ => Err(()),
+    }
+}
+
+fn first_char(s: &str) -> char {
+    s.chars().next().expect("empty locale string encountered")
+}

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -1,6 +1,9 @@
 //! Interactive menus for mkdev.
 mod locale;
 
+use std::fmt::Display;
+
+use inquire::list_option::ListOption;
 use locale::*;
 
 use crate::config::Config;
@@ -10,9 +13,11 @@ use crate::mkdev_error::Error;
 use crate::recipe::Recipe;
 
 use ignore::Walk;
-use inquire::formatter::BoolFormatter;
+use inquire::formatter::{BoolFormatter, MultiOptionFormatter};
 use inquire::parser::BoolParser;
-use inquire::{Confirm, MultiSelect, Text, error::InquireResult};
+use inquire::{
+    Confirm, MultiSelect, Text, error::InquireResult, validator::ValueRequiredValidator,
+};
 use rust_i18n::t;
 
 /// Interactively imprint a recipe from the current working directory.
@@ -54,7 +59,9 @@ pub fn confirm_recipe_overwrite(message: &str, default: bool) -> InquireResult<b
 }
 
 fn get_recipe_name() -> InquireResult<String> {
-    Text::new(&t!("menus.get_name")).prompt()
+    Text::new(&t!("menus.get_name"))
+        .with_validator(ValueRequiredValidator::new(t!("menus.name_required")))
+        .prompt()
 }
 
 fn get_recipe_description() -> InquireResult<String> {
@@ -62,11 +69,38 @@ fn get_recipe_description() -> InquireResult<String> {
 }
 
 fn select_contents(contents: Vec<RecipeItem>) -> InquireResult<Vec<RecipeItem>> {
+    let formatter: MultiOptionFormatter<RecipeItem> = &multiselect_truncate_formatter;
     let vim = Config::get()
         .expect("The config should be loaded at the top of a menu")
         .vim;
 
     MultiSelect::new(&t!("menus.filter_rec"), contents)
+        .with_all_selected_by_default()
+        .with_formatter(formatter)
+        .with_help_message(&t!("menus.multiselect_help"))
         .with_vim_mode(vim)
         .prompt()
+}
+
+fn multiselect_truncate_formatter<T>(opts: &[ListOption<&T>]) -> String
+where
+    T: Display,
+{
+    let len = opts.len();
+    let examples: Vec<_> = opts[0..len.min(3)].iter().map(|s| s.to_string()).collect();
+    let example_string = examples.join(", ");
+
+    match len {
+        0 => format!("{}", t!("menus.selected_count", count => 0)),
+        1..=3 => format!(
+            "{}: {}",
+            t!("menus.selected_count", count => len),
+            example_string
+        ),
+        4.. => format!(
+            "{}: {}, ...",
+            t!("menus.selected_count", count => len),
+            example_string
+        ),
+    }
 }

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -1,0 +1,72 @@
+//! Interactive menus for mkdev.
+mod locale;
+
+use locale::*;
+
+use crate::config::Config;
+use crate::content::{RecipeItem, make_contents};
+use crate::fs_wrappers::current_dir;
+use crate::mkdev_error::Error;
+use crate::recipe::Recipe;
+
+use ignore::Walk;
+use inquire::formatter::BoolFormatter;
+use inquire::parser::BoolParser;
+use inquire::{Confirm, MultiSelect, Text, error::InquireResult};
+use rust_i18n::t;
+
+/// Interactively imprint a recipe from the current working directory.
+pub fn imprint() -> Result<Recipe, Error> {
+    // Ensure the config is loaded in memory before proceeding.
+    let _config = Config::get()?;
+    let mut recipe = Recipe::default();
+    let cwd = current_dir()?;
+
+    let name = get_recipe_name()?;
+    recipe.name = name;
+
+    let description = get_recipe_description()?;
+    recipe.description = description;
+
+    let walk = Walk::new(cwd);
+    let default_contents = make_contents(walk)?;
+    recipe.contents = select_contents(default_contents)?;
+
+    let stage = recipe.materialise(None)?;
+    recipe.languages = Recipe::languages(stage.path());
+
+    Ok(recipe)
+}
+
+/// Find out if the user really wants to delete it for real.
+pub fn confirm_recipe_overwrite(message: &str, default: bool) -> InquireResult<bool> {
+    let parser: BoolParser = &locale_bool_parser;
+    let formatter: BoolFormatter = &locale_bool_formatter;
+    let default_formatter: BoolFormatter = &locale_bool_default_formatter;
+
+    Confirm::new(message)
+        .with_default(default)
+        .with_parser(parser)
+        .with_formatter(formatter)
+        .with_error_message(&t!("menus.invalid_yn"))
+        .with_default_value_formatter(default_formatter)
+        .prompt()
+}
+
+fn get_recipe_name() -> InquireResult<String> {
+    Text::new(&t!("menus.get_name")).prompt()
+}
+
+fn get_recipe_description() -> InquireResult<String> {
+    Text::new(&t!("menus.get_desc")).prompt()
+}
+
+fn select_contents(contents: Vec<RecipeItem>) -> InquireResult<Vec<RecipeItem>> {
+    let vim = Config::get()
+        .expect("The config should be loaded at the top of a menu")
+        .vim;
+
+    MultiSelect::new(&t!("menus.filter_rec"), contents)
+        .with_vim_mode(vim)
+        .prompt()
+}

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -30,6 +30,12 @@ pub enum Error {
     /// An error arising from trying to read a non-UTF-8 file.
     NotUTF8 { which: PathBuf },
 
+    /// Arises when the input device is not a TTY during interactive mode.
+    NotTTY,
+
+    /// Arises when the user cancels an interactive process.
+    InteractiveCancelled,
+
     /// Indicates that a value failed to serialise.
     #[allow(unused)]
     Serialisation {
@@ -82,6 +88,8 @@ impl std::fmt::Display for Error {
                 "{}",
                 t!("errors.not_utf8", file => which.to_string_lossy())
             ),
+            Error::NotTTY => write!(f, "{}", t!("errors.not_tty")),
+            Error::InteractiveCancelled => write!(f, "{}", t!("errors.interrupted")),
             Error::DestructionWarning { name } => {
                 write!(f, "{}", t!("errors.destruction", name => name))
             }
@@ -120,6 +128,7 @@ pub enum Context {
     Gather,
     Imprint,
     Man,
+    Tempfile,
 }
 
 impl std::fmt::Display for Context {
@@ -134,6 +143,7 @@ impl std::fmt::Display for Context {
                 Context::Gather => t!("context.gather"),
                 Context::Imprint => t!("contexts.imprint"),
                 Context::Man => t!("contexts.man"),
+                Context::Tempfile => t!("contexts.tempfile"),
             }
         )
     }
@@ -199,6 +209,17 @@ impl From<ignore::Error> for Error {
     fn from(e: ignore::Error) -> Self {
         Error::Exclude {
             cause: e.to_string(),
+        }
+    }
+}
+
+impl From<inquire::error::InquireError> for Error {
+    fn from(value: inquire::error::InquireError) -> Self {
+        match value {
+            inquire::InquireError::NotTTY => Error::NotTTY,
+            inquire::InquireError::OperationCanceled => Error::InteractiveCancelled,
+            inquire::InquireError::OperationInterrupted => Error::InteractiveCancelled,
+            _ => borked!(value),
         }
     }
 }

--- a/src/output_type.rs
+++ b/src/output_type.rs
@@ -1,3 +1,4 @@
+//! Display formats for `mk list`
 use clap::ValueEnum;
 
 #[derive(Debug, Clone, ValueEnum, Default)]

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -7,13 +7,13 @@ use super::Recipe;
 
 use crate::cli::Evoke;
 use crate::config::Config;
-use crate::content::RecipeItem;
+use crate::content::{File, RecipeItem};
 use crate::fs_wrappers;
-use crate::mkdev_error::Context;
 use crate::mkdev_error::{
     Error::{self, *},
     Subject,
 };
+use crate::recipe::{OnConflict, instantiate_contents};
 use crate::replacer::{InvalidTokenStrategy, ReplaceFmt};
 use crate::warning;
 
@@ -25,7 +25,83 @@ use rust_i18n::t;
 
 /// Evokes a recipe according to arguments from the command line.
 pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
-    // --- Error handling ---
+    // Make sure that the recipes past are valid.
+    validate_args(&args, &user_recipes)?;
+
+    // Build to the cwd, or a directory specified by the user
+    let dir = match &args.dir_name {
+        Some(dir) => PathBuf::from(dir),
+        None => fs_wrappers::current_dir()?,
+    };
+
+    let re = evocation_resolver(&args, &dir)?;
+
+    args.recipes.iter().try_for_each(|r| {
+        let recipe = user_recipes.get(r).expect("recipes were validated above.");
+        let contents = resolve_items(&recipe.contents, &re);
+        let on_conflict = if args.suppress_warnings {
+            OnConflict::Overwrite
+        } else {
+            OnConflict::Guard
+        };
+
+        // Context for failure, should building fail
+        instantiate_contents(&dir, &contents, on_conflict, args.verbose).inspect_err(|_| {
+            warning!(
+                "{}",
+                t!("errors.evoke", recipe => recipe.name, target => dir.display())
+            )
+        })
+    })
+}
+
+/// Applies a replacer to all the names and contents of a collection of RecipeItems, returning a
+/// new owned collection of them.
+fn resolve_items(contents: &[RecipeItem], re: &ReplaceFmt) -> Vec<RecipeItem> {
+    contents
+        .iter()
+        .map(|item| match item {
+            RecipeItem::File(file) => RecipeItem::File(File {
+                name: re.replace_path_with(run_shell, &file.name),
+                content: re.replace_with(run_shell, &file.content),
+            }),
+            RecipeItem::Directory(dir) => {
+                RecipeItem::Directory(re.replace_path_with(run_shell, dir))
+            }
+        })
+        .collect()
+}
+
+/// Runs the provided command.
+///
+/// Calculated reserved values (prefixed with 'mk::') are immediately dumped instead.
+fn run_shell(cmd: &str) -> Option<String> {
+    // Handle reserved names.
+    if cmd.starts_with("mk::") {
+        let out = cmd.strip_prefix("mk::").unwrap().to_string();
+        return Some(out);
+    }
+
+    let output = Command::new("sh").arg("-c").arg(cmd).output().ok();
+
+    match output {
+        Some(output) => {
+            // Convert to utf-8 text and strip the trailing newline (if there is one).
+            let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            if stdout.ends_with('\n') {
+                stdout.pop();
+            }
+            Some(stdout)
+        }
+        None => {
+            warning!("{}", t!("warnings.child_failed", child => cmd));
+            None
+        }
+    }
+}
+
+/// Verifies that at least one valid recipes was passed at the command line.
+fn validate_args(args: &Evoke, user_recipes: &HashMap<String, Recipe>) -> Result<(), Error> {
     // There is an error if no recipes are provided
     if args.recipes.is_empty() {
         return Err(NoneSpecified {
@@ -58,16 +134,15 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
         });
     }
 
-    // --- Replacer setup ---
+    Ok(())
+}
+
+/// Sets up the replacefmt used during evocation.
+fn evocation_resolver(args: &Evoke, dir: &Path) -> Result<ReplaceFmt, Error> {
     // Ensure project name is set to something
     let name = match args.name {
         Some(ref name) => name.clone(),
         None => "NAME".to_string(),
-    };
-    // Build to the cwd, or a directory specified by the user
-    let dir = match &args.dir_name {
-        Some(dir) => PathBuf::from(dir),
-        None => fs_wrappers::current_dir()?,
     };
 
     let user_subs: HashMap<_, _> = Config::get()?
@@ -82,109 +157,9 @@ pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Resu
         })
         .collect();
 
-    let re = ReplaceFmt::new(user_subs, ("{{", "}}"), InvalidTokenStrategy::Preserve);
-
-    // --- Build ---
-    let extra_args = args.clone();
-    args.recipes.iter().try_for_each(|r| {
-        let recipe = user_recipes.get(r).expect("recipes were validated above.");
-
-        // Context for failure, should building fail
-        build(&dir, &recipe.contents, &extra_args, &re).inspect_err(|_| {
-            warning!(
-                "{}",
-                t!("errors.evoke", recipe => recipe.name, target => dir.display())
-            )
-        })
-    })
-}
-
-/// Builds a single recipe by taking in its contents and instantiating it recursively
-fn build(
-    dir: &Path,
-    contents: &Vec<RecipeItem>,
-    extra_args: &Evoke,
-    re: &ReplaceFmt,
-) -> Result<(), Error> {
-    for content in contents {
-        let dest = dir.join(content.name());
-        ensure_parent(&dest)?;
-
-        match content {
-            RecipeItem::File(file) => {
-                // perform substitutions on the name and contents
-                let dest = PathBuf::from(re.replace_with(&dest.to_string_lossy(), run_shell));
-                let content = re.replace_with(&file.content, run_shell);
-
-                // Stop if a file would be overwritten unless the user has explicitly suppressed
-                // it.
-                if dest.is_file() && !extra_args.suppress_warnings {
-                    return Err(Error::DestructionWarning {
-                        name: dest.to_string_lossy().into(),
-                    });
-                }
-
-                if extra_args.verbose {
-                    eprintln!("{}", &dest.display());
-                }
-
-                fs_wrappers::write(&dest, content, Context::Evoke)?;
-            }
-            RecipeItem::Directory(dir_name) => {
-                // Perform substitutions on the dirname
-                let name = re.replace_with(&dir_name.to_string_lossy(), run_shell);
-                let dest = dir.join(name);
-
-                if extra_args.verbose {
-                    eprintln!("{}", &dest.display());
-                }
-
-                fs_wrappers::create_dir_all(&dest, Context::Evoke)?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Ensures that all parent directories of a file exist.
-fn ensure_parent(path: &Path) -> Result<(), Error> {
-    let parent = match path.parent() {
-        Some(p) => p,
-        None => return Ok(()),
-    };
-
-    if !parent.is_dir() {
-        fs_wrappers::create_dir_all(parent, Context::Evoke)?;
-    }
-
-    Ok(())
-}
-
-/// Runs the provided command.
-///
-/// Calculated reserved values (prefixed with 'mk::') are immediately dumped instead.
-fn run_shell(cmd: &str) -> Option<String> {
-    // Handle reserved names.
-    if cmd.starts_with("mk::") {
-        let out = cmd.strip_prefix("mk::").unwrap().to_string();
-        return Some(out);
-    }
-
-    let output = Command::new("sh").arg("-c").arg(cmd).output().ok();
-
-    match output {
-        Some(output) => {
-            // Convert to utf-8 text and strip the trailing newline (if there is one).
-            let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-            if stdout.ends_with('\n') {
-                stdout.pop();
-            }
-            Some(stdout)
-        }
-        None => {
-            warning!("{}", t!("warnings.child_failed", child => cmd));
-            None
-        }
-    }
+    Ok(ReplaceFmt::new(
+        user_subs,
+        ("{{", "}}"),
+        InvalidTokenStrategy::Preserve,
+    ))
 }

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -4,23 +4,28 @@
 //! the current directory recursively and stores the relative path and contents of all text files
 //! and subdirectories. Upon completion of this recursive walk, the contents are packed into a
 //! recipe struct and stored to the recipe directory.
-use super::{Language, Recipe, recipe_dir};
+use super::{Recipe, recipe_dir};
 use crate::cli::Imprint;
 use crate::content::{build_walk, make_contents};
 use crate::fs_wrappers;
+use crate::menus;
 use crate::mkdev_error::Context;
 use crate::mkdev_error::Error::{self, *};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use hyperpolyglot::get_language_breakdown;
 use ignore::Walk;
+use rust_i18n::t;
 
 /// Imprints a recipe using arguments from the command line, and post processes it accordingly.
 pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
-    let walker = build_walk(&args)?;
-    let new = Recipe::imprint(args.recipe, args.description, walker)?;
+    let new = if args.interactive {
+        menus::imprint()?
+    } else {
+        let walker = build_walk(&args)?;
+        Recipe::imprint(args.recipe, args.description, walker)?
+    };
 
     if let Some(path) = args.to_nix {
         let nix_expression = ser_nix::to_string(&new)
@@ -31,9 +36,23 @@ pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> R
         return Ok(());
     }
 
+    // Is the action going to overwrite an existing recipe?
     let destructive = user_recipes.iter().any(|(recipe, _)| recipe == &new.name);
 
-    if destructive && !args.suppress_warnings {
+    // If not, proceed, otherwise we defer to the user.
+    // If running interactively, use a prompt. Otherwise, check for the `-s` flag.
+    let can_proceed = !destructive
+        || if args.interactive {
+            menus::confirm_recipe_overwrite(
+                &t!("menus.recipe_overwrite", recipe => &new.name),
+                false,
+            )
+            .unwrap()
+        } else {
+            args.suppress_warnings
+        };
+
+    if !can_proceed {
         return Err(DestructionWarning { name: new.name });
     }
 
@@ -52,23 +71,7 @@ impl Recipe {
         let description = description.unwrap_or("".into());
 
         // Converts HashMap<&name, detected_info> -> Vec<(name, num_matching_files)>
-        let mut breakdown: Vec<_> = get_language_breakdown(".")
-            .iter()
-            .map(|(lang, files)| (*lang, files.len()))
-            .collect();
-
-        // Sort languages by number of matching files
-        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
-
-        let languages: Vec<_> = breakdown
-            .iter()
-            // Discard the count, as we only needed it to sort
-            .map(|(lang, _)| {
-                hyperpolyglot::Language::try_from(*lang)
-                    .expect("detected language come pre-validated.")
-            })
-            .map(Language::from)
-            .collect();
+        let languages = Recipe::languages(".");
 
         Ok(Self {
             name,

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -12,6 +12,7 @@ pub use imprint::*;
 pub use lang::Language;
 pub use list::*;
 
+use tempfile::TempDir;
 use version::*;
 
 use crate::config::Config;
@@ -21,14 +22,14 @@ use crate::mkdev_error::{Context, Error};
 use crate::warning;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dirs::data_dir;
 use rust_i18n::t;
 use serde::{Deserialize, Serialize};
 
 /// A mkdev recipe (v2).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Recipe {
     /// A unique identifier for the recipe.
     ///
@@ -78,6 +79,111 @@ impl Recipe {
 
         Ok(recipes)
     }
+
+    pub fn languages<P>(dir: P) -> Vec<Language>
+    where
+        P: AsRef<Path>,
+    {
+        let mut breakdown: Vec<_> = hyperpolyglot::get_language_breakdown(dir)
+            .iter()
+            .map(|(lang, files)| (*lang, files.len()))
+            .collect();
+
+        // Sort languages by number of matching files
+        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
+
+        breakdown
+            .iter()
+            // Discard the count, as we only needed it to sort
+            .map(|(lang, _)| {
+                hyperpolyglot::Language::try_from(*lang)
+                    .expect("detected language come pre-validated.")
+            })
+            .map(Language::from)
+            .collect()
+    }
+
+    /// Creates a temporary directory with all the files in the recipe instantiated on disk.
+    ///
+    /// Variable substitution does not occur. This is esentially an out-of-memory representation of
+    /// the recipe's `contents` field.
+    pub fn materialise(&self, maybe_dir: Option<&Path>) -> Result<TempDir, Error> {
+        let maybe_temp = match maybe_dir {
+            Some(ref dir) => tempfile::tempdir_in(dir),
+            None => tempfile::tempdir(),
+        };
+
+        let temp_dir = maybe_temp.map_err(|_| Error::FsDenied {
+            which: maybe_dir
+                .map(|p| p.into())
+                .unwrap_or_else(std::env::temp_dir),
+            context: Context::Tempfile,
+        })?;
+
+        instantiate_contents(
+            temp_dir.path(),
+            &self.contents,
+            OnConflict::Overwrite,
+            false,
+        )?;
+
+        Ok(temp_dir)
+    }
+}
+
+/// Builds a single recipe by taking in its contents and writing them to disk.
+///
+/// If a file in the target directory already exists and the conflict resolution strategy is not
+/// `Overwrite`, a Destruction error is returned.
+pub fn instantiate_contents(
+    dir: &Path,
+    contents: &[RecipeItem],
+    on_conflict: OnConflict,
+    verbose: bool,
+) -> Result<(), Error> {
+    contents.iter().try_for_each(|content| {
+        let dest = dir.join(content.name());
+        ensure_parent(&dest)?;
+
+        if verbose {
+            eprintln!("{}", &dest.display());
+        }
+
+        match content {
+            RecipeItem::File(file) => {
+                // Stop if a file would be overwritten unless the user has explicitly suppressed
+                // it.
+                match on_conflict {
+                    OnConflict::Guard if dest.is_file() => Err(Error::DestructionWarning {
+                        name: dest.to_string_lossy().into(),
+                    }),
+                    _ => fs_wrappers::write(&dest, &file.content, Context::Evoke),
+                }
+            }
+            RecipeItem::Directory(_) => fs_wrappers::create_dir_all(&dest, Context::Evoke),
+        }
+    })
+}
+
+/// What should happen if a file already exists in the target directory during evocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OnConflict {
+    Overwrite,
+    Guard,
+}
+
+/// Ensures that all parent directories of a file exist.
+fn ensure_parent(path: &Path) -> Result<(), Error> {
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    if !parent.is_dir() {
+        fs_wrappers::create_dir_all(parent, Context::Evoke)?;
+    }
+
+    Ok(())
 }
 
 /// Gets the user's preferred data dir, or uses the default XDG_DATA_DIR.

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -3,7 +3,10 @@
 //! This module is used to implement mkdev's recipe substitutions during `mk evoke` as well as
 //! formatting recipes for the default `mk list` behaviour.
 #![allow(dead_code)]
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 /// The primary interface for the formatter.
 ///
@@ -34,11 +37,20 @@ impl ReplaceFmt {
 
     /// Replaces all variables in `src` according to the formatter's internal mapping.
     pub fn replace(&self, src: &str) -> String {
-        self.replace_with(src, |val| Some(val.to_string()))
+        self.replace_with(|val| Some(val.to_string()), src)
+    }
+
+    /// Replaces all variables in a `Path` by applying `resolver` to them.
+    pub fn replace_path_with<F>(&self, resolver: F, path: &Path) -> PathBuf
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let input_str = path.to_string_lossy();
+        PathBuf::from(self.replace_with(resolver, &input_str))
     }
 
     /// Replaces all variables by applying `resolver` to the value in the internal mapping.
-    pub fn replace_with<F>(&self, src: &str, resolver: F) -> String
+    pub fn replace_with<F>(&self, resolver: F, src: &str) -> String
     where
         F: Fn(&str) -> Option<String>,
     {


### PR DESCRIPTION
This commit is the foundation for v3.5.0. There's a lot of changes all together, each with the shared purpose of adding interactive functionality to mkdev. This commit introduces a method to interactively create recipes.

Changes introduced:
---
- Refactor evocation logic into a multi-stage process that first does a pass to resolve variables with `ReplaceFmt` and second places the resolved content into the target directory. The standalone function `build` has been replaced by `resolve_items`, which does variable substitution on `RecipeContent` slices and `instantiate_contents` which takes places them in a target directory. Additionally the top-level `build_recipes` function has had several stages pulled out into standalone functions for readability.
- Inquire was added as a dependency. This allows us to prompt the user interactively.
- Added an interactive imprint menu. Takes in a name and description, then allows for file selection.
- Added some error types for interactive fail cases.
- `vim` config option that allows vim keybinds in multiselect scenarios
- Add `materialise` method that materialises an IR of the recipe's contents in a temporary directory--useful for looking at the file structure when a full evocation isn't desired
- Moved hyperpolyglot stuff out of imprint and into a standalone method.

TODO
---
- [x] Handle user providing empty recipe name (should not be allowed)
- [x] Add interactive prompting for the scenario where a nix file is the output rather than a toml one.
- [x] Probably a global `-i` alias