### PR TITLE
General Refactor + Interactive Recipe Editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,6 @@ dependencies = [
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
- "tempfile",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "ser_nix",
  "serde",
  "serde_json",
+ "strum",
  "sys-locale",
  "tempfile",
  "toml 0.8.23",
@@ -1268,6 +1269,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rust-i18n = "3.1.5"
 ser_nix = "0.2.2"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.140"
+strum = { version = "0.28.0", features = ["derive"] }
 sys-locale = "0.3.2"
 tempfile = "3.27.0"
 toml = "0.8.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ confique = { version = "0.4.0", features = ["toml"] }
 dirs = "5.0.1"
 hyperpolyglot = "0.1.7"
 ignore = "0.4.23"
-inquire = { version = "0.9.4", features = ["editor"] }
+inquire = { version = "0.9.4" }
 rust-i18n = "3.1.5"
 ser_nix = "0.2.2"
 serde = { version = "1.0.216", features = ["derive"] }

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -31,13 +31,11 @@ name_required = "A name for the recipe is required"
 selected_count = "%{count} files selected"
 
 [menus.editor] # Unique to the editor menu
-what_next = "Select the field to inspect/edit"
-what_action = "What would you like to do?"
+what_next = "Select the option to inspect/edit"
 curr_val = "Current Value"
 save = "You have unsaved changes."
-get_content_name = "Path for the new item:"
-select_content = "Select the file/directory to edit"
-get_item_contents = "Item Contents:"
+get_content_name = "Path for the new content:"
+select_content = "Select the file/directory to edit:"
 content_name_required = "A name is required"
 invalid_content_name = "Content with that name already exists, remove it first"
 

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -12,9 +12,14 @@ quit = "Quit"
 # The words for files and directories
 file = "File"
 directory = "Directory"
+# The word proceed (lemma form)
+proceed = "Proceed"
 
 [recipes]
 delete_msg = "Deleted recipe at %{path}."
+external = """This recipe is managed externally (e.g. by home-manager or GNU stow).
+It is safe to change: only the symlink will be updated, and the source will not be modified.
+You may need to make the same change in the source configuration manually."""
 
 # === Interactive Menus ===
 [menus] # Shared menu elements

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -36,9 +36,10 @@ what_action = "What would you like to do?"
 curr_val = "Current Value"
 save = "You have unsaved changes."
 get_content_name = "Path for the new item:"
+select_content = "Select the file/directory to edit"
 get_item_contents = "Item Contents:"
 content_name_required = "A name is required"
-invalid_content_name = "Content with that name already exists. Remove it first."
+invalid_content_name = "Content with that name already exists, remove it first"
 
 [editor.actions] # Things that are selected in the top-level menu
 add_content = "Add a file or directory"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -7,12 +7,53 @@ no = "No"
 # The word for yes and no, lowercase and ASCII-only.
 yes_simple = "yes"
 no_simple  = "no"
+# The word for quitting a process
+quit = "Quit"
+# The words for files and directories
+file = "File"
+directory = "Directory"
 
-[subject]
-recipe = "recipe"
-recipes = "recipes"
+[recipes]
+delete_msg = "Deleted recipe at %{path}."
 
-[contexts]
+# === Interactive Menus ===
+[menus] # Shared menu elements
+multiselect_help = "↑↓ to move, space to select one, → to all, ← to none, type to filter"
+recipe_overwrite = "This will overwrite the existing recipe '%{recipe}'. Are you sure?"
+select_help = "↑↓ to move, enter to select, type to filter"
+
+[menus.imprint] # Unique to the imprint menu
+filter_rec = "Select which files to include. Press enter to confirm."
+get_desc = "Recipe Description:"
+get_name = "Recipe Name:"
+invalid_yn = "Invalid answer, try typing 'y' for yes or 'n' for no"
+name_required = "A name for the recipe is required"
+selected_count = "%{count} files selected"
+
+[menus.editor] # Unique to the editor menu
+what_next = "Select the field to inspect/edit"
+what_action = "What would you like to do?"
+curr_val = "Current Value"
+save = "You have unsaved changes."
+get_content_name = "Path for the new item:"
+get_item_contents = "Item Contents:"
+content_name_required = "A name is required"
+invalid_content_name = "Content with that name already exists. Remove it first."
+
+[editor.actions] # Things that are selected in the top-level menu
+add_content = "Add a file or directory"
+edit_content = "Edit a file or directory"
+remove_contents = "Remove files or directories"
+description = "Edit recipe description"
+name = "Edit recipe name"
+
+[editor.exit] # Exit menu
+save = "Save changes and exit"
+exit = "Exit without saving"
+cancel = "Cancel"
+
+# === Error Handling ===
+[contexts] # What was happening when the error happened?
 config = "loading config"
 delete = "deleting recipe"
 evocation = "evoking recipe"
@@ -21,20 +62,7 @@ imprinting = "imprinting recipe"
 man = "generating man pages"
 tempfile = "creating temporary directory or file"
 
-[recipes]
-delete_msg = "Deleted recipe at %{path}."
-
-[menus]
-filter_rec = "Select which files to include. Press enter to confirm."
-get_desc = "Recipe Description:"
-get_name = "Recipe Name:"
-invalid_yn = "Invalid answer, try typing 'y' for yes or 'n' for no"
-recipe_overwrite = "This will overwrite the existing recipe '%{recipe}'. Are you sure?"
-name_required = "A name for the recipe is required"
-selected_count = "%{count} files selected"
-multiselect_help = "↑↓ to move, space to select one, → to all, ← to none, type to filter"
-
-[errors]
+[errors] # What went wrong?
 deserialise = "deserialization error: could not deserialize data from %{which} (while %{context})"
 destruction = "%{name} already exists; use -s to overwrite"
 evoke = "could not build `%{recipe}` in '%{target}'"
@@ -53,3 +81,7 @@ interrupted = "operation was interrupted"
 child_failed = "could not run command '%{child}'"
 invalid_recipe = "%{path} is not a valid recipe"
 storage_full = "storage full: could not write %{what}"
+
+[subject] # See errors.invalid
+recipe = "recipe"
+recipes = "recipes"

--- a/locales/es-AR.toml
+++ b/locales/es-AR.toml
@@ -1,2 +1,5 @@
 [menus]
 recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. ¿Seguro que querés sobrescribirla?"
+
+[menus.editor]
+save = "Tenés cambios sin guardar."

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -8,9 +8,13 @@ no_simple = "no"
 quit = "Salir"
 file = "Archivo"
 directory = "Directorio"
+proceed = "Continuar"
 
 [recipes]
 delete_msg = "Se eliminó la receta en %{path}."
+external = """Esta receta está gestionada externamente (p. ej., por home-manager o GNU stow).
+Es seguro cambiarla: solo se cambiará el enlace simbólico, y no se modificará el archivo original.
+Es posible que necesites hacer los cambios manualmente en la configuración original."""
 
 # === Interactive Menus ===
 [menus]

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -5,11 +5,49 @@ yes = "Sí"
 no = "No"
 yes_simple = "si"
 no_simple = "no"
+quit = "Salir"
+file = "Archivo"
+directory = "Directorio"
 
-[subject]
-recipe = "receta"
-recipes = "recetas"
+[recipes]
+delete_msg = "Se eliminó la receta en %{path}."
 
+# === Interactive Menus ===
+[menus]
+multiselect_help = "↑↓ para moverse, espacio para seleccionar uno, → para todos, ← para ninguno, escribe para filtrar"
+recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. ¿Seguro que quieres sobrescribirla?"
+select_help = "↑↓ para moverse, enter para seleccionar, escribe para filter"
+
+[menus.imprint]
+filter_rec = "Selecciona archivos para incluir. Presiona Enter para confirmar."
+get_desc = "Descripción de la Receta:"
+get_name = "Nombre de la Receta:"
+invalid_yn = "Respuesta inválida, intenta escribir 's' para sí o 'n' para no"
+name_required = "El nombre de la receta es obligatorio"
+selected_count = "%{count} archivos seleccionados"
+
+[menus.editor]
+what_next = "Selecciona el elemento para inspeccionar/editar"
+curr_val = "Valor Actual"
+save = "Tienes cambios sin guardar."
+get_content_name = "Ruta para el contenido nuevo"
+select_content = "Selecciona el archivo/directorio para editar:"
+content_name_required = "El nombre es obligatorio"
+invalid_content_name = "Ya existe un cotenido con ese nombre, elimínalo primero"
+
+[editor.actions]
+add_content = "Añadir un archivo o directorio"
+edit_content = "Editar un archivo o directorio"
+remove_contents = "Eliminar un archivo o directorio"
+description = "Editar la descripción de la receta"
+name = "Editar el nombre de la receta"
+
+[editor.exit]
+save = "Guardar cambios y salir"
+exit = "Salir sin guardar los cambios"
+cancel = "Cancelar"
+
+# === Error Handling ===
 [contexts]
 config = "cargar configuración"
 delete = "eliminar receta"
@@ -19,22 +57,6 @@ imprinting = "improntar receta"
 man = "generar páginas de manual"
 tempfile = "crear directorio o archivo temporal"
 
-[recipes]
-delete_msg = "Se eliminó la receta en %{path}."
-
-[menus]
-filter_rec = "Selecciona archivos para incluir. Presiona Enter para confirmar."
-get_desc = "Descripción de la Receta:"
-get_name = "Nombre de la Receta:"
-invalid_yn = "Respuesta inválida, intenta escribir 's' para sí o 'n' para no"
-recipe_overwrite = "La receta existente '%{recipe}' será sobrescrita. ¿Seguro que quieres sobrescribirla?"
-name_required = "El nombre de la receta es obligatorio"
-selected_count = "%{count} archivos seleccionados"
-multiselect_help = "↑↓ para moverse, espacio para seleccionar uno, → para todos, ← para ninguno, escribe para filtrar"
-
-# WARN: this requires that subject.* and errors.invalid and
-# errors.none_specified agree. Currently they do, but nothing guarantees this
-# for future changes.
 [errors]
 deserialise = "error de deserialización: no se pudo deserializar datos desde %{which} (%{context})"
 destruction = "%{name} ya existe; proporciona -s para sobrescribirlo"
@@ -54,3 +76,7 @@ interrupted = "la acción fue interrumpida"
 child_failed = "no se pudo ejecutar el comando '%{child}'"
 invalid_recipe = "%{path} no contiene una receta válida"
 storage_full = "almacenamiento lleno: no se pudo escribir %{what}"
+
+[subject]
+recipe = "receta"
+recipes = "recetas"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,8 @@ pub enum Commands {
     /// List recipes, or the contents of a specific one [Alias: show]
     #[command(aliases = ["show"])]
     List(List),
+    /// Edit a recipe in-place.
+    Edit(Edit),
 }
 
 #[derive(Parser, Clone, Debug)]
@@ -156,4 +158,10 @@ pub struct List {
     /// Hide description (note: only only applies default style)
     #[arg(long)]
     pub no_description: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct Edit {
+    /// The recipe to edit
+    pub recipe: String,
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -22,6 +22,7 @@ use crate::mkdev_error::Context;
 use crate::mkdev_error::Error;
 
 use std::cmp::Ordering;
+use std::path::Path;
 use std::path::PathBuf;
 
 use ignore::{Walk, WalkBuilder};
@@ -46,12 +47,6 @@ impl RecipeItem {
         name.into()
     }
 
-    /// Constructs a new `RecipeItem::File` variant
-    fn file(name: PathBuf) -> Result<Self, Error> {
-        let f = File::new(name)?;
-        Ok(Self::File(f))
-    }
-
     /// Constructs a new `RecipeItem::Directory` variant
     fn dir(name: PathBuf) -> Self {
         Self::Directory(name)
@@ -59,18 +54,10 @@ impl RecipeItem {
 }
 
 /// A file.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Hash)]
 pub struct File {
     pub name: PathBuf,
     pub content: String,
-}
-
-impl File {
-    pub fn new(name: PathBuf) -> Result<Self, Error> {
-        let content = fs_wrappers::read_to_string(&name, Context::Imprint)?;
-
-        Ok(Self { name, content })
-    }
 }
 
 /// Recursively detects and saves every file and subdirectory in the current working directory.
@@ -78,12 +65,11 @@ impl File {
 /// Standard ignore filters are applied (.gitignore, .ignore, etc.), and symlinks are ignored.
 ///
 /// Panics if an improperly constructed walk is made such that the current directory is invalid.
-pub fn make_contents(walk: Walk) -> Result<Vec<RecipeItem>, Error> {
-    let cwd = fs_wrappers::current_dir().expect("cwd should be checked in Walk constructor.");
+pub fn make_contents(walk: Walk, root: &Path) -> Result<Vec<RecipeItem>, Error> {
     let mut out = vec![];
 
     for file in walk.flatten() {
-        if file.path() == cwd {
+        if file.path() == root {
             continue;
         }
 
@@ -93,9 +79,9 @@ pub fn make_contents(walk: Walk) -> Result<Vec<RecipeItem>, Error> {
 
         let mut path = file.into_path();
 
-        if path.starts_with(&cwd) {
+        if path.starts_with(root) {
             path = path
-                .strip_prefix(&cwd)
+                .strip_prefix(root)
                 .expect("prefix is confirmed to exist")
                 .into();
         }
@@ -104,7 +90,10 @@ pub fn make_contents(walk: Walk) -> Result<Vec<RecipeItem>, Error> {
 
         // Make File or Directory variant as necessary
         match (is_file, is_dir, is_symlink) {
-            (true, false, false) => out.push(RecipeItem::file(path)?),
+            (true, false, false) => out.push(RecipeItem::File(File {
+                name: path.clone(),
+                content: fs_wrappers::read_to_string(root.join(path), Context::Imprint)?,
+            })),
             (false, true, false) => out.push(RecipeItem::dir(path)),
             // ignore symlinks (TODO: allow customisation with CLI)
             (false, false, true) => continue,
@@ -164,6 +153,21 @@ impl Ord for RecipeItem {
             (File(_), Directory(_)) => Ordering::Greater,
             (File(a), File(b)) => a.name.cmp(&b.name),
             (Directory(a), Directory(b)) => a.cmp(b),
+        }
+    }
+}
+
+impl std::hash::Hash for RecipeItem {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            RecipeItem::File(f) => {
+                0u8.hash(state);
+                f.name.hash(state);
+            }
+            RecipeItem::Directory(d) => {
+                1u8.hash(state);
+                d.hash(state);
+            }
         }
     }
 }

--- a/src/fs_wrappers.rs
+++ b/src/fs_wrappers.rs
@@ -107,6 +107,20 @@ where
     })
 }
 
+/// See std::fs::remove_file.
+pub fn remove_file<P>(path: P, ctx: Context) -> Result<(), Error>
+where
+    P: AsRef<Path> + Into<PathBuf>,
+{
+    fs::remove_file(&path).map_err(|e| match e.kind() {
+        ErrorKind::PermissionDenied => Error::FsDenied {
+            which: path.into(),
+            context: ctx,
+        },
+        _ => crate::borked!(e),
+    })
+}
+
 /// See std::env::current_dir.
 ///
 /// Returns handles permission errors. Immediately exits the program if the cwd is not found.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod replacer;
 
 use cli::{Cli, Commands::*};
 use hooks::hooks;
+use menus::editor;
 use recipe::Recipe;
 use recipe::{build_recipes, delete_recipe, imprint_recipe, list_recipe};
 
@@ -58,11 +59,13 @@ fn try_get_status(args: Cli) -> Result<(), mkdev_error::Error> {
     let user_recipes = Recipe::gather()?;
 
     match args.command {
+        // TODO: can probably be simplified with a trait or smth.
         Some(command) => match command {
             Evoke(sub_args) => build_recipes(sub_args, user_recipes),
             Imprint(sub_args) => imprint_recipe(sub_args, user_recipes),
             Delete(sub_args) => delete_recipe(sub_args, user_recipes),
             List(sub_args) => list_recipe(sub_args, user_recipes),
+            Edit(sub_args) => editor(sub_args, user_recipes),
         },
         None if args.interactive => {
             let fake_args = cli::Imprint {

--- a/src/menus/editor/actions.rs
+++ b/src/menus/editor/actions.rs
@@ -19,7 +19,7 @@ use crate::content::RecipeItem;
 use crate::menus::multiselect_truncate_formatter;
 use crate::recipe::Recipe;
 
-use super::{ContentType, EditorAction, prompt_new_name, replace_content};
+use super::{ContentType, EditorAction, prompt_new_name};
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -31,11 +31,28 @@ use inquire::{Editor, MultiSelect, Select, Text};
 use rust_i18n::t;
 use strum::IntoEnumIterator;
 
+/// Tries a skippable prompt, returning `Ok(false)` if the user skips the prompt.
 macro_rules! try_prompt {
     ($expr:expr) => {
         match $expr? {
             Some(val) => val,
             None => return Ok(false),
+        }
+    };
+}
+pub(crate) use try_prompt;
+
+/// Assigns a value with a new one if that new value is different.
+///
+/// Returns `true` if the value was changed.
+#[macro_export]
+macro_rules! set_if_changed {
+    ($l_val:expr, $r_val:expr) => {
+        if $l_val != $r_val {
+            $l_val = $r_val;
+            true
+        } else {
+            false
         }
     };
 }
@@ -52,12 +69,7 @@ impl EditorAction {
                 .prompt_skippable()
         );
 
-        if recipe.name != name {
-            recipe.name = name;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(set_if_changed!(recipe.name, name))
     }
 
     /// Change the description of the recipe.
@@ -68,12 +80,7 @@ impl EditorAction {
                 .prompt_skippable()
         );
 
-        if recipe.description != desc {
-            recipe.description = desc;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(set_if_changed!(recipe.description, desc))
     }
 
     /// Add a new file or directory.
@@ -102,11 +109,9 @@ impl EditorAction {
             try_prompt!(Select::new(&t!(""), ContentType::iter().collect()).prompt_skippable());
 
         match typ {
-            ContentType::Directory => {
-                recipe.contents.push(RecipeItem::Directory(path));
-                Ok(true)
-            }
             ContentType::File => {
+                // Determine the extension so that $EDITOR can see the filetype for highlighting +
+                // LSP.
                 let extension = path
                     .extension()
                     .unwrap_or_default()
@@ -126,35 +131,25 @@ impl EditorAction {
 
                 Ok(true)
             }
+            ContentType::Directory => {
+                recipe.contents.push(RecipeItem::Directory(path));
+                Ok(true)
+            }
         }
     }
 
     /// Change a file or directory.
     pub fn edit_content(&self, recipe: &mut Recipe) -> InquireResult<bool> {
-        let vim = Config::get()
-            .expect("The config should be loaded at the top of a menu")
-            .vim;
+        let vim = Config::get().unwrap().vim;
 
         let content_item = try_prompt!(
-            Select::new(&t!("menus.imprint.filter_rec"), recipe.contents.clone())
+            Select::new(&t!("menus.editor.select_content"), recipe.contents.clone())
                 .with_help_message(&t!("menus.select_help"))
                 .with_vim_mode(vim)
                 .prompt_skippable()
         );
 
         match content_item {
-            RecipeItem::Directory(ref p) => {
-                let name = try_prompt!(prompt_new_name(
-                    p.to_str().unwrap_or_default(),
-                    &recipe.contents
-                ));
-
-                Ok(replace_content(
-                    recipe,
-                    p,
-                    RecipeItem::Directory(PathBuf::from(name)),
-                ))
-            }
             RecipeItem::File(ref f) => {
                 let name = try_prompt!(prompt_new_name(
                     f.name.to_str().unwrap_or_default(),
@@ -175,8 +170,8 @@ impl EditorAction {
                         .prompt_skippable()
                 );
 
-                Ok(replace_content(
-                    recipe,
+                dbg!((&f.content, &content));
+                Ok(recipe.replace_content(
                     &f.name,
                     RecipeItem::File(crate::content::File {
                         name: path,
@@ -184,15 +179,21 @@ impl EditorAction {
                     }),
                 ))
             }
+            RecipeItem::Directory(ref p) => {
+                let name = try_prompt!(prompt_new_name(
+                    p.to_str().unwrap_or_default(),
+                    &recipe.contents
+                ));
+
+                Ok(recipe.replace_content(p, RecipeItem::Directory(PathBuf::from(name))))
+            }
         }
     }
 
     /// Select files and directories to remove from the recipe.
     pub fn remove_contents(&self, recipe: &mut Recipe) -> InquireResult<bool> {
         let formatter: MultiOptionFormatter<RecipeItem> = &multiselect_truncate_formatter;
-        let vim = Config::get()
-            .expect("The config should be loaded at the top of a menu")
-            .vim;
+        let vim = Config::get().unwrap().vim;
 
         let contents = try_prompt!(
             MultiSelect::new(&t!("menus.imprint.filter_rec"), recipe.contents.clone())

--- a/src/menus/editor/actions.rs
+++ b/src/menus/editor/actions.rs
@@ -20,7 +20,7 @@ use crate::menus::multiselect_truncate_formatter;
 use crate::recipe::Recipe;
 
 use super::file_editor::FileEditor;
-use super::{ContentType, EditorAction, prompt_new_name};
+use super::{ContentKind, EditorAction, prompt_new_name};
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -41,7 +41,6 @@ macro_rules! try_prompt {
         }
     };
 }
-pub(crate) use try_prompt;
 
 /// Assigns a value with a new one if that new value is different.
 ///
@@ -106,11 +105,11 @@ impl EditorAction {
         let path = PathBuf::from(name);
 
         // Get the type of content being added.
-        let typ =
-            try_prompt!(Select::new(&t!(""), ContentType::iter().collect()).prompt_skippable());
+        let content_kind =
+            try_prompt!(Select::new(&t!(""), ContentKind::iter().collect()).prompt_skippable());
 
-        match typ {
-            ContentType::File => {
+        match content_kind {
+            ContentKind::File => {
                 // Determine the extension so that $EDITOR can see the filetype for highlighting +
                 // LSP.
                 let extension = path
@@ -129,7 +128,7 @@ impl EditorAction {
 
                 Ok(true)
             }
-            ContentType::Directory => {
+            ContentKind::Directory => {
                 // Add the recipe into the directory.
                 recipe.contents.push(RecipeItem::Directory(path));
                 Ok(true)

--- a/src/menus/editor/actions.rs
+++ b/src/menus/editor/actions.rs
@@ -19,6 +19,7 @@ use crate::content::RecipeItem;
 use crate::menus::multiselect_truncate_formatter;
 use crate::recipe::Recipe;
 
+use super::file_editor::FileEditor;
 use super::{ContentType, EditorAction, prompt_new_name};
 
 use std::collections::HashSet;
@@ -27,7 +28,7 @@ use std::path::PathBuf;
 use inquire::error::InquireResult;
 use inquire::formatter::MultiOptionFormatter;
 use inquire::validator::{Validation, ValueRequiredValidator};
-use inquire::{Editor, MultiSelect, Select, Text};
+use inquire::{MultiSelect, Select, Text};
 use rust_i18n::t;
 use strum::IntoEnumIterator;
 
@@ -118,12 +119,9 @@ impl EditorAction {
                     .to_str()
                     .unwrap_or_default();
 
-                let contents = try_prompt!(
-                    Editor::new(&t!("menus.editor.get_item_contents"))
-                        .with_file_extension(&format!(".{extension}"))
-                        .prompt_skippable()
-                );
+                let contents = FileEditor::new("", extension).run()?;
 
+                // Add the file into the recipe.
                 recipe.contents.push(RecipeItem::File(crate::content::File {
                     name: path,
                     content: contents,
@@ -132,6 +130,7 @@ impl EditorAction {
                 Ok(true)
             }
             ContentType::Directory => {
+                // Add the recipe into the directory.
                 recipe.contents.push(RecipeItem::Directory(path));
                 Ok(true)
             }
@@ -140,37 +139,36 @@ impl EditorAction {
 
     /// Change a file or directory.
     pub fn edit_content(&self, recipe: &mut Recipe) -> InquireResult<bool> {
-        let vim = Config::get().unwrap().vim;
+        let use_vim_mode: bool = Config::get().unwrap().vim;
 
+        // Select the content to edit
         let content_item = try_prompt!(
             Select::new(&t!("menus.editor.select_content"), recipe.contents.clone())
                 .with_help_message(&t!("menus.select_help"))
-                .with_vim_mode(vim)
+                .with_vim_mode(use_vim_mode)
                 .prompt_skippable()
         );
 
         match content_item {
             RecipeItem::File(ref f) => {
+                // Determine the relative path the new file.
                 let name = try_prompt!(prompt_new_name(
                     f.name.to_str().unwrap_or_default(),
                     &recipe.contents
                 ));
-
                 let path = PathBuf::from(name);
+
+                // Get the extension for LSP support.
                 let extension = path
                     .extension()
                     .unwrap_or_default()
                     .to_str()
                     .unwrap_or_default();
 
-                let content = try_prompt!(
-                    Editor::new(&t!("menus.editor.get_item_contents"))
-                        .with_file_extension(&format!(".{extension}"))
-                        .with_predefined_text(&f.content)
-                        .prompt_skippable()
-                );
+                // Launch the editor.
+                let content = FileEditor::new(&f.content, extension).run()?;
 
-                dbg!((&f.content, &content));
+                // Make the changes if necessary.
                 Ok(recipe.replace_content(
                     &f.name,
                     RecipeItem::File(crate::content::File {
@@ -180,11 +178,13 @@ impl EditorAction {
                 ))
             }
             RecipeItem::Directory(ref p) => {
+                // Determine the relative path to the new directory.
                 let name = try_prompt!(prompt_new_name(
                     p.to_str().unwrap_or_default(),
                     &recipe.contents
                 ));
 
+                // Make the changes if necessary.
                 Ok(recipe.replace_content(p, RecipeItem::Directory(PathBuf::from(name))))
             }
         }
@@ -193,18 +193,25 @@ impl EditorAction {
     /// Select files and directories to remove from the recipe.
     pub fn remove_contents(&self, recipe: &mut Recipe) -> InquireResult<bool> {
         let formatter: MultiOptionFormatter<RecipeItem> = &multiselect_truncate_formatter;
-        let vim = Config::get().unwrap().vim;
+        let use_vim_mode = Config::get().unwrap().vim;
 
+        // Select contents to remove.
         let contents = try_prompt!(
             MultiSelect::new(&t!("menus.imprint.filter_rec"), recipe.contents.clone())
                 .with_formatter(formatter)
                 .with_help_message(&t!("menus.multiselect_help"))
-                .with_vim_mode(vim)
+                .with_vim_mode(use_vim_mode)
                 .prompt_skippable()
         );
 
-        let lookup: HashSet<_> = contents.into_iter().collect();
-        recipe.contents.retain(|r| !lookup.contains(r));
+        // Bail if there's nothing to delete.
+        if contents.is_empty() {
+            return Ok(false);
+        }
+
+        // Remove the specified paths.
+        let paths_to_remove: HashSet<_> = contents.into_iter().collect();
+        recipe.contents.retain(|r| !paths_to_remove.contains(r));
         Ok(true)
     }
 }

--- a/src/menus/editor/actions.rs
+++ b/src/menus/editor/actions.rs
@@ -1,0 +1,209 @@
+// mkdev - Save your boilerplate instead of writing it
+// Copyright (C) 2026  James C. Craven <4jamesccraven@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//! Implementation for editing specific attributes in the editor.
+use crate::config::Config;
+use crate::content::RecipeItem;
+use crate::menus::multiselect_truncate_formatter;
+use crate::recipe::Recipe;
+
+use super::{ContentType, EditorAction, prompt_new_name, replace_content};
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use inquire::error::InquireResult;
+use inquire::formatter::MultiOptionFormatter;
+use inquire::validator::{Validation, ValueRequiredValidator};
+use inquire::{Editor, MultiSelect, Select, Text};
+use rust_i18n::t;
+use strum::IntoEnumIterator;
+
+macro_rules! try_prompt {
+    ($expr:expr) => {
+        match $expr? {
+            Some(val) => val,
+            None => return Ok(false),
+        }
+    };
+}
+
+impl EditorAction {
+    /// Change the name of the recipe.
+    pub fn edit_name(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        let name = try_prompt!(
+            Text::new(&t!("menus.imprint.get_name"))
+                .with_validator(ValueRequiredValidator::new(t!(
+                    "menus.imprint.name_required"
+                )))
+                .with_initial_value(&recipe.name)
+                .prompt_skippable()
+        );
+
+        if recipe.name != name {
+            recipe.name = name;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Change the description of the recipe.
+    pub fn edit_description(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        let desc = try_prompt!(
+            Text::new(&t!("menus.imprint.get_desc"))
+                .with_initial_value(&recipe.description)
+                .prompt_skippable()
+        );
+
+        if recipe.description != desc {
+            recipe.description = desc;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Add a new file or directory.
+    pub fn add_content(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        // Get the new content's name.
+        let name = try_prompt!(
+            Text::new(&t!("menus.editor.get_content_name"))
+                .with_validator(ValueRequiredValidator::new(t!(
+                    "menus.editor.content_name_required"
+                )))
+                .with_validator(|i: &str| {
+                    if recipe.contents.iter().any(|item| item.name() == i) {
+                        Ok(Validation::Invalid(
+                            t!("menus.editor.invalid_content_name").into(),
+                        ))
+                    } else {
+                        Ok(Validation::Valid)
+                    }
+                })
+                .prompt_skippable()
+        );
+        let path = PathBuf::from(name);
+
+        // Get the type of content being added.
+        let typ =
+            try_prompt!(Select::new(&t!(""), ContentType::iter().collect()).prompt_skippable());
+
+        match typ {
+            ContentType::Directory => {
+                recipe.contents.push(RecipeItem::Directory(path));
+                Ok(true)
+            }
+            ContentType::File => {
+                let extension = path
+                    .extension()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
+
+                let contents = try_prompt!(
+                    Editor::new(&t!("menus.editor.get_item_contents"))
+                        .with_file_extension(&format!(".{extension}"))
+                        .prompt_skippable()
+                );
+
+                recipe.contents.push(RecipeItem::File(crate::content::File {
+                    name: path,
+                    content: contents,
+                }));
+
+                Ok(true)
+            }
+        }
+    }
+
+    /// Change a file or directory.
+    pub fn edit_content(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        let vim = Config::get()
+            .expect("The config should be loaded at the top of a menu")
+            .vim;
+
+        let content_item = try_prompt!(
+            Select::new(&t!("menus.imprint.filter_rec"), recipe.contents.clone())
+                .with_help_message(&t!("menus.select_help"))
+                .with_vim_mode(vim)
+                .prompt_skippable()
+        );
+
+        match content_item {
+            RecipeItem::Directory(ref p) => {
+                let name = try_prompt!(prompt_new_name(
+                    p.to_str().unwrap_or_default(),
+                    &recipe.contents
+                ));
+
+                Ok(replace_content(
+                    recipe,
+                    p,
+                    RecipeItem::Directory(PathBuf::from(name)),
+                ))
+            }
+            RecipeItem::File(ref f) => {
+                let name = try_prompt!(prompt_new_name(
+                    f.name.to_str().unwrap_or_default(),
+                    &recipe.contents
+                ));
+
+                let path = PathBuf::from(name);
+                let extension = path
+                    .extension()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default();
+
+                let content = try_prompt!(
+                    Editor::new(&t!("menus.editor.get_item_contents"))
+                        .with_file_extension(&format!(".{extension}"))
+                        .with_predefined_text(&f.content)
+                        .prompt_skippable()
+                );
+
+                Ok(replace_content(
+                    recipe,
+                    &f.name,
+                    RecipeItem::File(crate::content::File {
+                        name: path,
+                        content,
+                    }),
+                ))
+            }
+        }
+    }
+
+    /// Select files and directories to remove from the recipe.
+    pub fn remove_contents(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        let formatter: MultiOptionFormatter<RecipeItem> = &multiselect_truncate_formatter;
+        let vim = Config::get()
+            .expect("The config should be loaded at the top of a menu")
+            .vim;
+
+        let contents = try_prompt!(
+            MultiSelect::new(&t!("menus.imprint.filter_rec"), recipe.contents.clone())
+                .with_formatter(formatter)
+                .with_help_message(&t!("menus.multiselect_help"))
+                .with_vim_mode(vim)
+                .prompt_skippable()
+        );
+
+        let lookup: HashSet<_> = contents.into_iter().collect();
+        recipe.contents.retain(|r| !lookup.contains(r));
+        Ok(true)
+    }
+}

--- a/src/menus/editor/file_editor.rs
+++ b/src/menus/editor/file_editor.rs
@@ -1,0 +1,103 @@
+// mkdev - Save your boilerplate instead of writing it
+// Copyright (C) 2026  James C. Craven <4jamesccraven@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+//
+// Portions of this file are derived from the `inquire` crate:
+// https://github.com/mikaelmello/inquire
+//
+// Original work licensed under the MIT License.
+// Copyright (c) 2021 Mikael Mello
+//
+// See inquire.MIT.txt for the full license text.
+
+//! Support for opening the editor.
+//!
+//! Why not use the one the one from `inquire`? It strips newlines from the user's "input," meaning
+//! that genuinely desired newlines do not make it into the final recipe, and thus silently changes
+//! user data.
+use std::io::Write;
+use std::path::Path;
+use std::{env, process};
+
+use inquire::error::InquireResult;
+use tempfile::NamedTempFile;
+
+/// Edits long-form text inside the user's preferred $EDITOR.
+pub struct FileEditor<'a> {
+    buf: String,
+    ext: &'a str,
+}
+
+impl<'a> FileEditor<'a> {
+    pub fn new(current: &str, ext: &'a str) -> Self {
+        Self {
+            buf: current.to_string(),
+            ext,
+        }
+    }
+
+    /// Run the file editor.
+    pub fn run(mut self) -> InquireResult<String> {
+        let tmp = self.init_tmp()?;
+        self.spawn_editor(tmp.path())?;
+        self.buf = std::fs::read_to_string(tmp.path())?;
+
+        Ok(self.buf)
+    }
+
+    /// Initialise a temporary file to edit into.
+    fn init_tmp(&self) -> InquireResult<NamedTempFile> {
+        let mut tmp_file = tempfile::Builder::new()
+            .prefix("tmp-")
+            .suffix(&format!(".{}", self.ext))
+            .rand_bytes(10)
+            .tempfile()?;
+
+        tmp_file.write_all(self.buf.as_bytes())?;
+        tmp_file.flush()?;
+
+        Ok(tmp_file)
+    }
+
+    /// Run the user's editor on a path.
+    fn spawn_editor(&mut self, file: &Path) -> InquireResult<()> {
+        process::Command::new(Self::get_editor())
+            .arg(file)
+            .spawn()?
+            .wait()?;
+
+        Ok(())
+    }
+
+    /// Get the user's preferred editor or default to nano.
+    fn get_editor() -> String {
+        let mut default_editor = String::from("nano");
+
+        if let Ok(editor) = env::var("EDITOR")
+            && !editor.is_empty()
+        {
+            default_editor = editor;
+        }
+
+        if let Ok(editor) = env::var("VISUAL")
+            && !editor.is_empty()
+        {
+            default_editor = editor;
+        }
+
+        default_editor
+    }
+}

--- a/src/menus/editor/inquire.MIT.txt
+++ b/src/menus/editor/inquire.MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Mikael Mello
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -1,0 +1,256 @@
+// mkdev - Save your boilerplate instead of writing it
+// Copyright (C) 2026  James C. Craven <4jamesccraven@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//! An editor to modify an existing recipe.
+mod actions;
+
+use crate::cli::Edit;
+use crate::config::Config;
+use crate::content::RecipeItem;
+use crate::mkdev_error::Error;
+use crate::recipe::Recipe;
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use colored::Colorize;
+use inquire::error::InquireResult;
+use inquire::validator::{Validation, ValueRequiredValidator};
+use inquire::{Select, Text};
+use rust_i18n::t;
+use strum::IntoEnumIterator;
+
+/// Invoke an editor that continuously allows inspection and editing of various data within the
+/// recipe.
+///
+/// On exit, the user may choose to save the recipe, at which point it is canonicalised and then
+/// saved to the recipe directory.
+pub fn editor(args: Edit, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
+    // Ensure the config is loaded in memory before proceeding.
+    let _config = Config::get()?;
+    let mut recipe = Recipe::pick(&user_recipes, &args.recipe)?.clone();
+    let mut recipe_altered = false;
+
+    loop {
+        // Target field/action,
+        let action = EditorAction::select_action()?;
+
+        // Handle quitting.
+        if let EditorAction::Quit = action {
+            if EditorAction::quit_menu(recipe_altered, &recipe)? {
+                break;
+            } else {
+                continue;
+            }
+        }
+
+        // Try to dispatch an edit. If it succeeds and a change is made, update `recipe_altered`
+        // and print a newline for readability.
+        recipe_altered |= action.dispatch(&mut recipe)?;
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Actions that the editor can take
+#[derive(Clone, Copy, Debug, strum::EnumIter)]
+enum EditorAction {
+    Name,
+    Description,
+    AddContent,
+    EditContent,
+    RemoveContents,
+    Quit,
+}
+
+impl EditorAction {
+    /// Selects the next action the editor should take.
+    fn select_action() -> InquireResult<EditorAction> {
+        let message = &t!("menus.editor.what_next");
+        let opts: Vec<_> = EditorAction::iter().collect();
+        let vim = Config::get().unwrap().vim;
+
+        Select::new(message, opts)
+            .with_vim_mode(vim)
+            .with_help_message(&t!("menus.select_help"))
+            .prompt()
+    }
+
+    /// Handles exiting the editor.
+    ///
+    /// If the editor should close, `Ok(true)` is returned. `altered` informs whether or not a recipe has
+    /// been altered. If it hasn't the editor simply closes. If the recipe has been altered, the user
+    /// is presented with the choice to save and exit, exit without saving, or cancel (not exit).
+    fn quit_menu(altered: bool, recipe: &Recipe) -> Result<bool, Error> {
+        if !altered {
+            Ok(true)
+        } else {
+            let opts = ExitAction::iter().collect();
+            let prompt = Select::new(&t!("menus.editor.save"), opts).prompt_skippable()?;
+
+            let Some(choice) = prompt else {
+                return Ok(false);
+            };
+
+            match choice {
+                ExitAction::Save => {
+                    recipe.save()?;
+                    Ok(true)
+                }
+                ExitAction::Exit => Ok(true),
+                ExitAction::Cancel => Ok(false),
+            }
+        }
+    }
+
+    /// Inspect the field if applicable, then run the edit dialogue.
+    ///
+    /// Returns `Ok(true)` if an edit has been made.
+    pub fn dispatch(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        self.inspect(recipe);
+        self.edit(recipe)
+    }
+
+    /// Dispatcher for the different fields that can be edited.
+    ///
+    /// Returns `Ok(true)` if an edit has been made.
+    fn edit(&self, recipe: &mut Recipe) -> InquireResult<bool> {
+        match self {
+            Self::AddContent => self.add_content(recipe),
+            Self::Description => self.edit_description(recipe),
+            Self::EditContent => self.edit_content(recipe),
+            Self::Name => self.edit_name(recipe),
+            Self::RemoveContents => self.remove_contents(recipe),
+            Self::Quit => unreachable!(),
+        }
+    }
+
+    /// Present the current value of the given field if applicable, do nothing otherwise.
+    fn inspect(&self, recipe: &Recipe) {
+        let val = match self {
+            Self::Name => format!("\"{}\"", recipe.name),
+            Self::Description => format!("\"{}\"", recipe.description),
+            Self::AddContent | Self::RemoveContents | Self::EditContent => recipe
+                .display_contents()
+                .lines()
+                .collect::<Vec<_>>()
+                .join("\n  "),
+            _ => return,
+        };
+
+        println!(
+            "{} {}:\n  {}",
+            ">".green(),
+            t!("menus.editor.curr_val"),
+            val
+        )
+    }
+}
+
+/// Prompts a name for new content item.
+fn prompt_new_name(current: &str, existing: &[RecipeItem]) -> InquireResult<Option<String>> {
+    let msg = &t!("menus.editor.get_content_name");
+    Text::new(msg)
+        .with_validator(ValueRequiredValidator::new(t!(
+            "menus.editor.content_name_required"
+        )))
+        .with_validator(|i: &str| {
+            if i == current || !existing.iter().any(|item| item.name() == i) {
+                Ok(Validation::Valid)
+            } else {
+                Ok(Validation::Invalid(
+                    t!("menus.editor.invalid_content_name").into(),
+                ))
+            }
+        })
+        .with_initial_value(current)
+        .prompt_skippable()
+}
+
+/// Replaces a specific item in a recipe with a new one.
+///
+/// Returns `true` if the value was successfully found a replaced.
+fn replace_content(recipe: &mut Recipe, old_name: &Path, new_item: RecipeItem) -> bool {
+    match recipe
+        .contents
+        .iter_mut()
+        .find(|item| &item.name() == old_name)
+    {
+        Some(item) => {
+            *item = new_item;
+            true
+        }
+        None => false,
+    }
+}
+
+impl std::fmt::Display for EditorAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AddContent => t!("editor.actions.add_content"),
+                Self::Description => t!("editor.actions.description"),
+                Self::EditContent => t!("editor.actions.edit_content"),
+                Self::Name => t!("editor.actions.name"),
+                Self::Quit => t!("general.quit"),
+                Self::RemoveContents => t!("editor.actions.remove_contents"),
+            }
+        )
+    }
+}
+
+/// Strategy enum that dictates what happens when a user tries to exit with unsaved changes.
+#[derive(Clone, Copy, Debug, strum::EnumIter)]
+enum ExitAction {
+    Save,
+    Exit,
+    Cancel,
+}
+
+impl std::fmt::Display for ExitAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Save => t!("editor.exit.save"),
+                Self::Exit => t!("editor.exit.exit"),
+                Self::Cancel => t!("editor.exit.cancel"),
+            }
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, strum::EnumIter)]
+enum ContentType {
+    File,
+    Directory,
+}
+
+impl std::fmt::Display for ContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::File => t!("general.file"),
+                Self::Directory => t!("general.directory"),
+            }
+        )
+    }
+}

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -17,10 +17,13 @@
 mod actions;
 mod file_editor;
 
+use super::confirm_action;
+
 use crate::cli::Edit;
 use crate::config::Config;
 use crate::content::RecipeItem;
-use crate::mkdev_error::Error;
+use crate::fs_wrappers;
+use crate::mkdev_error::{Context, Error};
 use crate::recipe::Recipe;
 
 use std::collections::HashMap;
@@ -40,8 +43,17 @@ use strum::IntoEnumIterator;
 pub fn editor(args: Edit, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     // Ensure the config is loaded in memory before proceeding.
     let _config = Config::get()?;
+
     let mut recipe = Recipe::pick(&user_recipes, &args.recipe)?.clone();
     let mut recipe_altered = false;
+
+    let original_path = recipe.dwelling()?;
+    let was_external = recipe.is_external()?;
+    let external_msg = format!(
+        "{} – {}?",
+        t!("recipes.external", name => &recipe.name),
+        t!("general.proceed")
+    );
 
     loop {
         // Target field/action,
@@ -51,7 +63,22 @@ pub fn editor(args: Edit, user_recipes: HashMap<String, Recipe>) -> Result<(), E
         if matches!(action, EditorAction::Quit) {
             match EditorAction::quit_menu(recipe_altered)? {
                 ExitAction::Save => {
+                    // Give the user the opportunity to quit if the recipe is or was externally
+                    // managed.
+                    if (recipe.is_external()? || was_external)
+                        && !confirm_action(&external_msg, true)?
+                    {
+                        continue;
+                    }
+
+                    // Store the recipe's new path.
+                    let new_path = recipe.dwelling()?;
                     recipe.save()?;
+
+                    // If the recipe's path changed, delete the old file/link.
+                    if new_path != original_path {
+                        fs_wrappers::remove_file(original_path, Context::Imprint)?;
+                    }
                     break;
                 }
                 ExitAction::Exit => break,

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -23,7 +23,6 @@ use crate::mkdev_error::Error;
 use crate::recipe::Recipe;
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use colored::Colorize;
 use inquire::error::InquireResult;
@@ -129,10 +128,10 @@ impl EditorAction {
     /// Returns `Ok(true)` if an edit has been made.
     fn edit(&self, recipe: &mut Recipe) -> InquireResult<bool> {
         match self {
-            Self::AddContent => self.add_content(recipe),
-            Self::Description => self.edit_description(recipe),
-            Self::EditContent => self.edit_content(recipe),
             Self::Name => self.edit_name(recipe),
+            Self::Description => self.edit_description(recipe),
+            Self::AddContent => self.add_content(recipe),
+            Self::EditContent => self.edit_content(recipe),
             Self::RemoveContents => self.remove_contents(recipe),
             Self::Quit => unreachable!(),
         }
@@ -178,23 +177,6 @@ fn prompt_new_name(current: &str, existing: &[RecipeItem]) -> InquireResult<Opti
         })
         .with_initial_value(current)
         .prompt_skippable()
-}
-
-/// Replaces a specific item in a recipe with a new one.
-///
-/// Returns `true` if the value was successfully found a replaced.
-fn replace_content(recipe: &mut Recipe, old_name: &Path, new_item: RecipeItem) -> bool {
-    match recipe
-        .contents
-        .iter_mut()
-        .find(|item| &item.name() == old_name)
-    {
-        Some(item) => {
-            *item = new_item;
-            true
-        }
-        None => false,
-    }
 }
 
 impl std::fmt::Display for EditorAction {

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -17,8 +17,6 @@
 mod actions;
 mod file_editor;
 
-use actions::try_prompt;
-
 use crate::cli::Edit;
 use crate::config::Config;
 use crate::content::RecipeItem;
@@ -50,11 +48,14 @@ pub fn editor(args: Edit, user_recipes: HashMap<String, Recipe>) -> Result<(), E
         let action = EditorAction::select_action()?;
 
         // Handle quitting.
-        if let EditorAction::Quit = action {
-            if EditorAction::quit_menu(recipe_altered, &recipe)? {
-                break;
-            } else {
-                continue;
+        if matches!(action, EditorAction::Quit) {
+            match EditorAction::quit_menu(recipe_altered)? {
+                ExitAction::Save => {
+                    recipe.save()?;
+                    break;
+                }
+                ExitAction::Exit => break,
+                ExitAction::Cancel => continue,
             }
         }
 
@@ -96,22 +97,17 @@ impl EditorAction {
     /// If the editor should close, `Ok(true)` is returned. `altered` informs whether or not a recipe has
     /// been altered. If it hasn't the editor simply closes. If the recipe has been altered, the user
     /// is presented with the choice to save and exit, exit without saving, or cancel (not exit).
-    fn quit_menu(altered: bool, recipe: &Recipe) -> Result<bool, Error> {
+    fn quit_menu(altered: bool) -> Result<ExitAction, Error> {
         if !altered {
-            Ok(true)
+            Ok(ExitAction::Exit)
         } else {
             let opts = ExitAction::iter().collect();
-            let choice =
-                try_prompt!(Select::new(&t!("menus.editor.save"), opts).prompt_skippable());
+            let choice = Select::new(&t!("menus.editor.save"), opts).prompt_skippable()?;
 
-            match choice {
-                ExitAction::Save => {
-                    recipe.save()?;
-                    Ok(true)
-                }
-                ExitAction::Exit => Ok(true),
-                ExitAction::Cancel => Ok(false),
-            }
+            Ok(match choice {
+                Some(act) => act,
+                None => ExitAction::Cancel,
+            })
         }
     }
 
@@ -159,6 +155,23 @@ impl EditorAction {
     }
 }
 
+impl std::fmt::Display for EditorAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AddContent => t!("editor.actions.add_content"),
+                Self::Description => t!("editor.actions.description"),
+                Self::EditContent => t!("editor.actions.edit_content"),
+                Self::Name => t!("editor.actions.name"),
+                Self::Quit => t!("general.quit"),
+                Self::RemoveContents => t!("editor.actions.remove_contents"),
+            }
+        )
+    }
+}
+
 /// Prompts a name for new content item.
 fn prompt_new_name(current: &str, existing: &[RecipeItem]) -> InquireResult<Option<String>> {
     let msg = &t!("menus.editor.get_content_name");
@@ -177,23 +190,6 @@ fn prompt_new_name(current: &str, existing: &[RecipeItem]) -> InquireResult<Opti
         })
         .with_initial_value(current)
         .prompt_skippable()
-}
-
-impl std::fmt::Display for EditorAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::AddContent => t!("editor.actions.add_content"),
-                Self::Description => t!("editor.actions.description"),
-                Self::EditContent => t!("editor.actions.edit_content"),
-                Self::Name => t!("editor.actions.name"),
-                Self::Quit => t!("general.quit"),
-                Self::RemoveContents => t!("editor.actions.remove_contents"),
-            }
-        )
-    }
 }
 
 /// Strategy enum that dictates what happens when a user tries to exit with unsaved changes.
@@ -219,12 +215,12 @@ impl std::fmt::Display for ExitAction {
 }
 
 #[derive(Clone, Copy, Debug, strum::EnumIter)]
-enum ContentType {
+enum ContentKind {
     File,
     Directory,
 }
 
-impl std::fmt::Display for ContentType {
+impl std::fmt::Display for ContentKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //! An editor to modify an existing recipe.
 mod actions;
+mod file_editor;
+
+use actions::try_prompt;
 
 use crate::cli::Edit;
 use crate::config::Config;
@@ -98,11 +101,8 @@ impl EditorAction {
             Ok(true)
         } else {
             let opts = ExitAction::iter().collect();
-            let prompt = Select::new(&t!("menus.editor.save"), opts).prompt_skippable()?;
-
-            let Some(choice) = prompt else {
-                return Ok(false);
-            };
+            let choice =
+                try_prompt!(Select::new(&t!("menus.editor.save"), opts).prompt_skippable());
 
             match choice {
                 ExitAction::Save => {

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -57,7 +57,7 @@ pub fn imprint() -> Result<Recipe, Error> {
     Ok(recipe)
 }
 
-/// Find out if the user really wants to delete it for real.
+/// Prompt the user to confirm something.
 pub fn confirm_action(message: &str, default: bool) -> InquireResult<bool> {
     let parser: BoolParser = &locale_bool_parser;
     let formatter: BoolFormatter = &locale_bool_formatter;

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //! Interactive menus for mkdev.
+mod editor;
 mod locale;
 
 use std::fmt::Display;
 
-use inquire::list_option::ListOption;
+pub use editor::editor;
 use locale::*;
 
 use crate::config::Config;
@@ -28,11 +29,12 @@ use crate::mkdev_error::Error;
 use crate::recipe::Recipe;
 
 use ignore::Walk;
+use inquire::error::InquireResult;
 use inquire::formatter::{BoolFormatter, MultiOptionFormatter};
+use inquire::list_option::ListOption;
 use inquire::parser::BoolParser;
-use inquire::{
-    Confirm, MultiSelect, Text, error::InquireResult, validator::ValueRequiredValidator,
-};
+use inquire::validator::ValueRequiredValidator;
+use inquire::{Confirm, MultiSelect, Text};
 use rust_i18n::t;
 
 /// Interactively imprint a recipe from the current working directory.
@@ -48,8 +50,8 @@ pub fn imprint() -> Result<Recipe, Error> {
     let description = get_recipe_description()?;
     recipe.description = description;
 
-    let walk = Walk::new(cwd);
-    let default_contents = make_contents(walk)?;
+    let walk = Walk::new(&cwd);
+    let default_contents = make_contents(walk, &cwd)?;
     recipe.contents = select_contents(default_contents)?;
 
     let stage = recipe.materialise(None)?;
@@ -59,7 +61,7 @@ pub fn imprint() -> Result<Recipe, Error> {
 }
 
 /// Find out if the user really wants to delete it for real.
-pub fn confirm_recipe_overwrite(message: &str, default: bool) -> InquireResult<bool> {
+pub fn confirm_action(message: &str, default: bool) -> InquireResult<bool> {
     let parser: BoolParser = &locale_bool_parser;
     let formatter: BoolFormatter = &locale_bool_formatter;
     let default_formatter: BoolFormatter = &locale_bool_default_formatter;
@@ -68,19 +70,21 @@ pub fn confirm_recipe_overwrite(message: &str, default: bool) -> InquireResult<b
         .with_default(default)
         .with_parser(parser)
         .with_formatter(formatter)
-        .with_error_message(&t!("menus.invalid_yn"))
+        .with_error_message(&t!("menus.imprint.invalid_yn"))
         .with_default_value_formatter(default_formatter)
         .prompt()
 }
 
 fn get_recipe_name() -> InquireResult<String> {
-    Text::new(&t!("menus.get_name"))
-        .with_validator(ValueRequiredValidator::new(t!("menus.name_required")))
+    Text::new(&t!("menus.imprint.get_name"))
+        .with_validator(ValueRequiredValidator::new(t!(
+            "menus.imprint.name_required"
+        )))
         .prompt()
 }
 
 fn get_recipe_description() -> InquireResult<String> {
-    Text::new(&t!("menus.get_desc")).prompt()
+    Text::new(&t!("menus.imprint.get_desc")).prompt()
 }
 
 fn select_contents(contents: Vec<RecipeItem>) -> InquireResult<Vec<RecipeItem>> {
@@ -89,7 +93,7 @@ fn select_contents(contents: Vec<RecipeItem>) -> InquireResult<Vec<RecipeItem>> 
         .expect("The config should be loaded at the top of a menu")
         .vim;
 
-    MultiSelect::new(&t!("menus.filter_rec"), contents)
+    MultiSelect::new(&t!("menus.imprint.filter_rec"), contents)
         .with_all_selected_by_default()
         .with_formatter(formatter)
         .with_help_message(&t!("menus.multiselect_help"))
@@ -106,15 +110,15 @@ where
     let example_string = examples.join(", ");
 
     match len {
-        0 => format!("{}", t!("menus.selected_count", count => 0)),
+        0 => format!("{}", t!("menus.imprint.selected_count", count => 0)),
         1..=3 => format!(
             "{}: {}",
-            t!("menus.selected_count", count => len),
+            t!("menus.imprint.selected_count", count => len),
             example_string
         ),
         4.. => format!(
             "{}: {}, ...",
-            t!("menus.selected_count", count => len),
+            t!("menus.imprint.selected_count", count => len),
             example_string
         ),
     }

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -54,9 +54,6 @@ pub fn imprint() -> Result<Recipe, Error> {
     let default_contents = make_contents(walk, &cwd)?;
     recipe.contents = select_contents(default_contents)?;
 
-    let stage = recipe.materialise(None)?;
-    recipe.languages = Recipe::languages(stage.path());
-
     Ok(recipe)
 }
 

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -171,6 +171,19 @@ pub enum Subject {
     Recipes,
 }
 
+impl Subject {
+    /// Gets the correct plurality from a count.
+    ///
+    /// Panics if 0 is passed.
+    pub fn from_count(count: usize) -> Self {
+        match count {
+            1 => Self::Recipe,
+            2.. => Self::Recipes,
+            0 => crate::borked!(count),
+        }
+    }
+}
+
 impl std::fmt::Display for Subject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -19,10 +19,7 @@
 use super::{Recipe, recipe_dir};
 use crate::cli::Delete;
 use crate::mkdev_error::Context;
-use crate::mkdev_error::{
-    Error::{self, *},
-    Subject,
-};
+use crate::mkdev_error::Error;
 
 use std::collections::HashMap;
 use std::fs;
@@ -33,24 +30,15 @@ use rust_i18n::t;
 
 /// Deletes a recipe based on command line arguments.
 pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
-    let to_delete = user_recipes.get(args.recipe.as_str());
+    let to_delete = Recipe::pick(&user_recipes, &args.recipe)?;
+    let deleted_file = to_delete.delete()?;
 
-    match to_delete {
-        Some(recipe) => {
-            let deleted_file = recipe.delete()?;
+    println!(
+        "{}",
+        t!("recipes.delete_msg", path => &deleted_file.display())
+    );
 
-            println!(
-                "{}",
-                t!("recipes.delete_msg", path => &deleted_file.display())
-            );
-
-            Ok(())
-        }
-        None => Err(Invalid {
-            subject: Subject::Recipe,
-            examples: Some(vec![args.recipe]),
-        }),
-    }
+    Ok(())
 }
 
 impl Recipe {

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -16,7 +16,7 @@
 //! Implementation of `mk delete`.
 //!
 //! Used to delete recipes from their default location.
-use super::{Recipe, recipe_dir};
+use super::Recipe;
 use crate::cli::Delete;
 use crate::mkdev_error::Context;
 use crate::mkdev_error::Error;
@@ -42,20 +42,18 @@ pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Res
 }
 
 impl Recipe {
-    /// Delete the recipe by deleting its serialised self
+    /// Delete the recipe by deleting its serialised self.
     pub fn delete(&self) -> Result<PathBuf, Error> {
-        let mut data_dir = recipe_dir()?;
+        let recipe_file = self.dwelling()?;
 
-        data_dir.push(format!("{}.toml", self.name));
-
-        fs::remove_file(&data_dir).map_err(|e| match e.kind() {
+        fs::remove_file(&recipe_file).map_err(|e| match e.kind() {
             ErrorKind::PermissionDenied => Error::FsDenied {
-                which: data_dir.clone(),
+                which: recipe_file.clone(),
                 context: Context::Delete,
             },
             _ => crate::borked!(e),
         })?;
 
-        Ok(data_dir)
+        Ok(recipe_file)
     }
 }

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -18,12 +18,12 @@
 //! Used to delete recipes from their default location.
 use super::Recipe;
 use crate::cli::Delete;
+use crate::fs_wrappers;
 use crate::mkdev_error::Context;
 use crate::mkdev_error::Error;
+use crate::warning;
 
 use std::collections::HashMap;
-use std::fs;
-use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use rust_i18n::t;
@@ -46,13 +46,10 @@ impl Recipe {
     pub fn delete(&self) -> Result<PathBuf, Error> {
         let recipe_file = self.dwelling()?;
 
-        fs::remove_file(&recipe_file).map_err(|e| match e.kind() {
-            ErrorKind::PermissionDenied => Error::FsDenied {
-                which: recipe_file.clone(),
-                context: Context::Delete,
-            },
-            _ => crate::borked!(e),
-        })?;
+        if self.is_external()? {
+            warning!("{}", t!("recipes.external"));
+        }
+        fs_wrappers::remove_file(&recipe_file, Context::Delete)?;
 
         Ok(recipe_file)
     }

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -124,30 +124,8 @@ fn validate_args(args: &Evoke, user_recipes: &HashMap<String, Recipe>) -> Result
         });
     }
 
-    let non_existant_recipes: Vec<String> = args
-        .recipes
-        .iter()
-        .filter_map(|r| match user_recipes.contains_key(r) {
-            false => {
-                let r = r.to_string();
-                Some(r)
-            }
-            true => None,
-        })
-        .collect();
-
-    // There is an error if there are any non-existent recipes specified by the user
-    if !non_existant_recipes.is_empty() {
-        let subject = match non_existant_recipes.len() {
-            1 => Subject::Recipe,
-            2.. => Subject::Recipes,
-            _ => unreachable!(),
-        };
-        return Err(Invalid {
-            subject,
-            examples: Some(non_existant_recipes),
-        });
-    }
+    // Validate existence of all recipes
+    _ = Recipe::pick_many(user_recipes, &args.recipes)?;
 
     Ok(())
 }

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -19,7 +19,7 @@
 //! the current directory recursively and stores the relative path and contents of all text files
 //! and subdirectories. Upon completion of this recursive walk, the contents are packed into a
 //! recipe struct and stored to the recipe directory.
-use super::{Recipe, recipe_dir};
+use super::Recipe;
 use crate::cli::Imprint;
 use crate::content::{build_walk, make_contents};
 use crate::fs_wrappers::{self, current_dir};
@@ -93,17 +93,54 @@ impl Recipe {
         })
     }
 
-    /// Save the recipe object by serialising self into the data directory
-    pub fn save(&self) -> Result<PathBuf, Error> {
+    /// Ensures that a recipe's data is canonical.
+    ///
+    /// `canonicalise` builds the recipe in a temporary directory, and imprints that directory,
+    /// preserving the metadata associated with the potentially non-canonical self. This ensures
+    /// that all directories are explicitly modeled, for example.
+    pub fn canonicalise(&self) -> Result<Self, Error> {
         let temp_dir = self.materialise(None)?;
-        let true_contents = make_contents(Walk::new(temp_dir.path()), temp_dir.path())?;
+        let contents = make_contents(Walk::new(temp_dir.path()), temp_dir.path())?;
+        let languages = Recipe::languages(temp_dir.path());
 
-        let canonical_recipe = Self {
-            contents: true_contents,
+        Ok(Self {
+            contents,
+            languages,
             ..self.clone()
-        };
+        })
+    }
 
-        let recipe_file = recipe_dir()?.join(format!("{}.toml", self.name));
+    /// Determines if the recipe is externally managed.
+    ///
+    /// A recipe is considered to be externally managed if it already exists and is a symlink.
+    /// If the recipe is a symlink, that implies that the source of truth for the recipe is not the
+    /// file in the recipe_dir itself, and can thus be safely deleted before the recipe saves
+    /// itself.
+    pub fn is_external(&self) -> Result<bool, Error> {
+        let recipe_file = self.dwelling()?;
+
+        if !recipe_file.exists() {
+            return Ok(false);
+        }
+
+        let metadata = std::fs::symlink_metadata(&recipe_file).map_err(|_| Error::FsDenied {
+            which: recipe_file,
+            context: Context::Imprint,
+        })?;
+        Ok(metadata.is_symlink())
+    }
+
+    /// Save the recipe object by serialising `self` into the data directory.
+    pub fn save(&self) -> Result<PathBuf, Error> {
+        let canonical_recipe = self.canonicalise()?;
+        let recipe_file = self.dwelling()?;
+
+        if self.is_external()? {
+            std::fs::remove_file(&recipe_file).map_err(|_| FsDenied {
+                which: recipe_file.clone(),
+                context: Context::Imprint,
+            })?;
+        }
 
         fs_wrappers::write(
             &recipe_file,

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -23,9 +23,9 @@ use super::Recipe;
 use crate::cli::Imprint;
 use crate::content::{build_walk, make_contents};
 use crate::fs_wrappers::{self, current_dir};
-use crate::menus;
 use crate::mkdev_error::Context;
 use crate::mkdev_error::Error::{self, *};
+use crate::{menus, warning};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -63,6 +63,10 @@ pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> R
         } else {
             args.suppress_warnings
         };
+
+    if destructive && new.is_external()? {
+        warning!("{}", t!("recipes.external"));
+    }
 
     if !can_proceed {
         return Err(DestructionWarning { name: new.name });
@@ -139,10 +143,7 @@ impl Recipe {
         let recipe_file = self.dwelling()?;
 
         if self.is_external()? {
-            std::fs::remove_file(&recipe_file).map_err(|_| FsDenied {
-                which: recipe_file.clone(),
-                context: Context::Imprint,
-            })?;
+            fs_wrappers::remove_file(&recipe_file, Context::Imprint)?;
         }
 
         fs_wrappers::write(

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -22,7 +22,7 @@
 use super::{Recipe, recipe_dir};
 use crate::cli::Imprint;
 use crate::content::{build_walk, make_contents};
-use crate::fs_wrappers;
+use crate::fs_wrappers::{self, current_dir};
 use crate::menus;
 use crate::mkdev_error::Context;
 use crate::mkdev_error::Error::{self, *};
@@ -58,11 +58,8 @@ pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> R
     // If running interactively, use a prompt. Otherwise, check for the `-s` flag.
     let can_proceed = !destructive
         || if args.interactive {
-            menus::confirm_recipe_overwrite(
-                &t!("menus.recipe_overwrite", recipe => &new.name),
-                false,
-            )
-            .unwrap()
+            menus::confirm_action(&t!("menus.recipe_overwrite", recipe => &new.name), false)
+                .unwrap()
         } else {
             args.suppress_warnings
         };
@@ -81,7 +78,7 @@ pub fn imprint_recipe(args: Imprint, user_recipes: HashMap<String, Recipe>) -> R
 impl Recipe {
     /// Create a `Recipe` by imprinting/cloning the contents of the cwd
     pub fn imprint(name: String, description: Option<String>, walker: Walk) -> Result<Self, Error> {
-        let contents = make_contents(walker)?;
+        let contents = make_contents(walker, &current_dir()?)?;
 
         let description = description.unwrap_or("".into());
 
@@ -98,16 +95,22 @@ impl Recipe {
 
     /// Save the recipe object by serialising self into the data directory
     pub fn save(&self) -> Result<PathBuf, Error> {
-        let mut data_dir = recipe_dir()?;
+        let temp_dir = self.materialise(None)?;
+        let true_contents = make_contents(Walk::new(temp_dir.path()), temp_dir.path())?;
 
-        data_dir.push(format!("{}.toml", self.name));
+        let canonical_recipe = Self {
+            contents: true_contents,
+            ..self.clone()
+        };
+
+        let recipe_file = recipe_dir()?.join(format!("{}.toml", self.name));
 
         fs_wrappers::write(
-            &data_dir,
-            toml::to_string_pretty(&self).unwrap(),
+            &recipe_file,
+            toml::to_string_pretty(&canonical_recipe).unwrap(),
             Context::Imprint,
         )?;
 
-        Ok(data_dir)
+        Ok(recipe_file)
     }
 }

--- a/src/recipe/imprint.rs
+++ b/src/recipe/imprint.rs
@@ -98,7 +98,7 @@ impl Recipe {
     /// `canonicalise` builds the recipe in a temporary directory, and imprints that directory,
     /// preserving the metadata associated with the potentially non-canonical self. This ensures
     /// that all directories are explicitly modeled, for example.
-    pub fn canonicalise(&self) -> Result<Self, Error> {
+    pub fn to_canonical(&self) -> Result<Self, Error> {
         let temp_dir = self.materialise(None)?;
         let contents = make_contents(Walk::new(temp_dir.path()), temp_dir.path())?;
         let languages = Recipe::languages(temp_dir.path());
@@ -130,9 +130,12 @@ impl Recipe {
         Ok(metadata.is_symlink())
     }
 
-    /// Save the recipe object by serialising `self` into the data directory.
-    pub fn save(&self) -> Result<PathBuf, Error> {
-        let canonical_recipe = self.canonicalise()?;
+    /// Save the recipe object by serialising a canonicalised `self` into the data directory.
+    ///
+    /// This consumes the recipe, as the previous representation may not be valid after
+    /// canonicalisation.
+    pub fn save(self) -> Result<PathBuf, Error> {
+        let canonical_recipe = self.to_canonical()?;
         let recipe_file = self.dwelling()?;
 
         if self.is_external()? {

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -144,7 +144,32 @@ impl Recipe {
             .collect())
     }
 
-    /// TODO: missing docs
+    /// Replaces a specific item in a recipe with a new one.
+    ///
+    /// Returns `true` if the value was successfully found and replaced. Returns `false` if no matching
+    /// item was found or if the item was a different type (i.e., setting a File to a Directory and vice
+    /// versa)
+    pub fn replace_content(&mut self, old_name: &Path, new_item: RecipeItem) -> bool {
+        use crate::set_if_changed;
+        match self
+            .contents
+            .iter_mut()
+            .find(|item| &item.name() == old_name)
+        {
+            Some(item) => match (item, new_item) {
+                (RecipeItem::File(f), RecipeItem::File(other)) => {
+                    set_if_changed!(f.name, other.name) || set_if_changed!(f.content, other.content)
+                }
+                (RecipeItem::Directory(d), RecipeItem::Directory(other)) => {
+                    set_if_changed!(*d, other)
+                }
+                _ => false,
+            },
+            None => false,
+        }
+    }
+
+    /// Generate a breakdown of the languages in a directory.
     pub fn languages<P>(dir: P) -> Vec<Language>
     where
         P: AsRef<Path>,
@@ -172,6 +197,7 @@ impl Recipe {
     ///
     /// Variable substitution does not occur. This is esentially an out-of-memory representation of
     /// the recipe's `contents` field.
+    // TODO: refactor to avoid `Option` parameter.
     pub fn materialise(&self, maybe_dir: Option<&Path>) -> Result<TempDir, Error> {
         let maybe_temp = match maybe_dir {
             Some(ref dir) => tempfile::tempdir_in(dir),
@@ -193,6 +219,13 @@ impl Recipe {
         )?;
 
         Ok(temp_dir)
+    }
+
+    /// The location on disk where a recipe should live.
+    ///
+    /// Returns `Err` if the user's data directory cannot be determined.
+    pub fn dwelling(&self) -> Result<PathBuf, Error> {
+        Ok(recipe_dir()?.join(format!("{}.toml", self.name)))
     }
 }
 
@@ -252,7 +285,7 @@ fn ensure_parent(path: &Path) -> Result<(), Error> {
 }
 
 /// Gets the user's preferred data dir, or uses the default XDG_DATA_DIR.
-pub fn recipe_dir() -> Result<PathBuf, Error> {
+fn recipe_dir() -> Result<PathBuf, Error> {
     let cfg = Config::get()?;
 
     let data_dir = match &cfg.recipe_dir {

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -180,7 +180,7 @@ impl Recipe {
             .collect();
 
         // Sort languages by number of matching files
-        breakdown.sort_by(|a, b| b.1.cmp(&a.1));
+        breakdown.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         breakdown
             .iter()

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -33,7 +33,7 @@ use version::*;
 use crate::config::Config;
 use crate::content::RecipeItem;
 use crate::fs_wrappers;
-use crate::mkdev_error::{Context, Error};
+use crate::mkdev_error::{Context, Error, Subject};
 use crate::warning;
 
 use std::collections::HashMap;
@@ -95,6 +95,56 @@ impl Recipe {
         Ok(recipes)
     }
 
+    /// Validates and returns a reference to one recipe in a map of many.
+    ///
+    /// Returns `Error::Invalid` if there is no such recipe.
+    pub fn pick<'recipes>(
+        map: &'recipes HashMap<String, Recipe>,
+        name: &str,
+    ) -> Result<&'recipes Recipe, Error> {
+        map.get(name).ok_or_else(|| Error::Invalid {
+            subject: Subject::Recipe,
+            examples: Some(vec![name.into()]),
+        })
+    }
+
+    /// Validates and returns a list of reference to several recipes from a map of them.
+    ///
+    /// Returns `Error::Invalid` if there are no such recipe(s).
+    pub fn pick_many<'recipes, S>(
+        map: &'recipes HashMap<String, Recipe>,
+        names: &[S],
+    ) -> Result<Vec<&'recipes Recipe>, Error>
+    where
+        S: AsRef<str>,
+    {
+        let fake_recipes: Vec<&str> = names
+            .iter()
+            .map(|s| s.as_ref())
+            .filter(|n| !map.contains_key(*n))
+            .collect();
+
+        if !fake_recipes.is_empty() {
+            let count = fake_recipes.len();
+            return Err(Error::Invalid {
+                subject: Subject::from_count(count),
+                examples: Some(
+                    fake_recipes
+                        .into_iter()
+                        .map(|name| name.to_string())
+                        .collect(),
+                ),
+            });
+        }
+
+        Ok(names
+            .iter()
+            .map(|s| s.as_ref())
+            .map(|name| map.get(name).unwrap())
+            .collect())
+    }
+
+    /// TODO: missing docs
     pub fn languages<P>(dir: P) -> Vec<Language>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
Interactive recipe editing + several enhancements and refactors to recipe logic.

*Recipe Editor*
- Change the name, description, and contents of a recipe interactively with `mk edit`
- Get LSP support for the contents of a recipe's files by invoking `$EDITOR` while editing them.

*General Refactor*
- Recipes are now made "canonical" before saving. This entails copying the recipe to a temporary directory and creating a new representation based on that directory (using the typical imprint machinery).
- Common logic such as instantiating recipe(s), verifying their existence, and getting their location on disk have been extracted into standalone functions to unify behaviour.
- Functionality has been added to detect if a recipe is externally managed (i.e., is a symlink from something like home-manager or gnu stow).