### PR TITLE
Recipe Namespaces

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -70,18 +70,19 @@ man = "generating man pages"
 tempfile = "creating temporary directory or file"
 
 [errors] # What went wrong?
+ambiguous = "ambiguous query"
 deserialise = "deserialization error: could not deserialize data from %{which} (while %{context})"
 destruction = "%{name} already exists; use -s to overwrite"
 evoke = "could not build `%{recipe}` in '%{target}'"
 exclude = "imprint: invalid value for flag `--exclude`"
 fs_denied = "permission denied: could not access %{which} (while %{context})"
+interrupted = "operation was interrupted"
 invalid = "invalid %{subject}"
 no_cwd = "the current directory does not exist"
 none_specified = "no %{subject} specified"
 not_tty = "the input device is not a TTY"
 not_utf8 = "%{file} is not valid UTF-8"
 serialise = "serialization error: could not serialize data to %{which} (while %{context})"
-interrupted = "operation was interrupted"
 
 [warnings]
 child_failed = "could not run command '%{child}'"

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -65,18 +65,19 @@ man = "generar páginas de manual"
 tempfile = "crear directorio o archivo temporal"
 
 [errors]
+ambiguous = "búsqueda ambigua"
 deserialise = "error de deserialización: no se pudo deserializar datos desde %{which} (%{context})"
 destruction = "%{name} ya existe; proporciona -s para sobrescribirlo"
 evoke = "no se pudo construir `%{recipe}` en '%{target}'"
 exclude = "improntar: se proporcionó un valor inválido al argumento `--exclude`"
 fs_denied = "permiso denegado: no se pudo acceder a %{which} (%{context})"
+interrupted = "la acción fue interrumpida"
 invalid = "%{subject} inválida(s)"
 no_cwd = "el directorio de trabajo actual no existe"
 none_specified = "no se especificó ninguna(s) %{subject}"
 not_tty = "el dispositivo de entrada no es un teletipo"
 not_utf8 = "%{file} no contiene datos UTF-8 válidos"
 serialise = "error de serialización: no se pudo serializar datos a %{which} (%{context})"
-interrupted = "la acción fue interrumpida"
 
 [warnings]
 child_failed = "no se pudo ejecutar el comando '%{child}'"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -180,9 +180,13 @@ pub struct Imprint {
 
 #[derive(Parser, Debug)]
 pub struct Delete {
-    /// The recipe to delete
+    /// The recipe/namespace to delete
     #[arg(add = ArgValueCompleter::new(recipe_completer))]
     pub recipe: String,
+
+    /// Delete an entire namespace.
+    #[arg(long)]
+    pub namespace: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/display/display_config.rs
+++ b/src/display/display_config.rs
@@ -46,11 +46,29 @@ pub struct DisplayConfig {
     #[serde(default = "default_recipe_fmt")]
     pub recipe_fmt: String,
 
-    // --- Name ---
-    /// How to format the name of the recipe. (use "{name}" to reference the raw name).
+    // --- Namespace ---
+    /// How to format the namespace divider. Use "{namespace}" to reference the namespace. If the
+    /// namespace_fmt is empty, namespace dividers are not shown. Leading newlines are stripped for
+    /// the first given namespace.
     ///
     /// Default:
-    /// "{name}"
+    /// "\n--- {namespace} ---"
+    #[serde(default = "default_namespace_fmt")]
+    pub namespace_fmt: String,
+    /// Whether the namespace divider should always show even if only the global namespace exists.
+    ///
+    /// Default:
+    /// false
+    #[serde(default = "default_namespace_show_always")]
+    pub namespace_show_always: bool,
+
+    // --- Name ---
+    /// How to format the name of the recipe. Use "{name}" to reference the full recipe name (with
+    /// the namespace), "{namespace}" to reference the namespace, or "{shortname}" to reference the
+    /// short name.
+    ///
+    /// Default:
+    /// "{shortname}"
     #[serde(default = "default_name_fmt")]
     pub name_fmt: String,
     /// Whether the name should be bolded.
@@ -81,6 +99,7 @@ pub struct DisplayConfig {
     ///
     /// Default:
     /// true
+    #[serde(default = "default_lang_colour")]
     pub lang_colour: bool,
     /// Text that joins formatted languages.
     ///
@@ -97,6 +116,8 @@ impl Default for DisplayConfig {
             recipes_suffix: default_recipes_suffix(),
             show_descriptions: None,
             recipe_fmt: default_recipe_fmt(),
+            namespace_fmt: default_namespace_fmt(),
+            namespace_show_always: default_namespace_show_always(),
             name_fmt: default_name_fmt(),
             name_bold: default_name_bold(),
             desc_fmt: default_desc_fmt(),
@@ -111,13 +132,15 @@ use config_defaults::*;
 #[rustfmt::skip]
 mod config_defaults {
     //! Source of truth for `DisplayConfig::default` implementation
-    pub fn default_recipes_join()   -> String { "\n".to_string()                     }
-    pub fn default_recipes_suffix() -> String { "\n".to_string()                     }
-    pub fn default_recipe_fmt()     -> String { "{name} ({langs}){desc}".to_string() }
-    pub fn default_name_fmt()       -> String { "{name}".to_string()                 }
-    pub fn default_name_bold()      -> bool   { true                                 }
-    pub fn default_desc_fmt()       -> String { "\n  {desc}".to_string()             }
-    pub fn default_lang_fmt()       -> String { "{lang}".to_string()                 }
-    pub fn default_lang_colour()    -> bool   { true                                 }
-    pub fn default_langs_join()     -> String { " ".to_string()                      }
+    pub fn default_recipes_join()          -> String { "\n".to_string()                     }
+    pub fn default_recipes_suffix()        -> String { "\n".to_string()                     }
+    pub fn default_recipe_fmt()            -> String { "{name} ({langs}){desc}".to_string() }
+    pub fn default_namespace_fmt()         -> String { "\n--- {namespace} ---".to_string()  }
+    pub fn default_namespace_show_always() -> bool   { false                                }
+    pub fn default_name_fmt()              -> String { "{shortname}".to_string()            }
+    pub fn default_name_bold()             -> bool   { true                                 }
+    pub fn default_desc_fmt()              -> String { "\n  {desc}".to_string()             }
+    pub fn default_lang_fmt()              -> String { "{lang}".to_string()                 }
+    pub fn default_lang_colour()           -> bool   { true                                 }
+    pub fn default_langs_join()            -> String { " ".to_string()                      }
 }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -32,12 +32,42 @@ const FALLBACK: InvalidTokenStrategy = InvalidTokenStrategy::Preserve;
 
 /// Formats and displays a list of recipes according to a provided configuration.
 pub fn display_recipes_with_config(recipes: &[&Recipe], config: &DisplayConfig) -> String {
-    recipes
-        .iter()
-        .map(|r| cfg_display_recipe(r, config))
-        .collect::<Vec<String>>()
-        .join(&config.recipes_join)
-        + config.recipes_suffix.as_str()
+    let additional_namespaces = !recipes.iter().all(|r| r.namespace().is_none());
+    let mut prev_ns = recipes.first().and_then(|r| r.namespace());
+
+    // Only show the Global namespace header if there are others or if the user's config requests
+    // it.
+    let mut lines = if additional_namespaces || config.namespace_show_always {
+        let first_line = cfg_display_namespace(prev_ns, config)
+            .trim_start_matches('\n')
+            .to_string();
+        vec![first_line]
+    } else {
+        Vec::new()
+    };
+
+    for recipe in recipes {
+        let curr_ns = recipe.namespace();
+        if curr_ns != prev_ns {
+            lines.push(cfg_display_namespace(curr_ns, config));
+        }
+
+        lines.push(cfg_display_recipe(recipe, config));
+
+        prev_ns = curr_ns;
+    }
+
+    lines.join("\n") + &config.recipes_suffix
+}
+
+/// Formats a namespace divider according to a provided configuration.
+fn cfg_display_namespace(namespace: Option<&str>, config: &DisplayConfig) -> String {
+    let subs = HashMap::from([(
+        "namespace".to_string(),
+        namespace.unwrap_or("Globals").to_string(),
+    )]);
+
+    replace(subs, &config.namespace_fmt)
 }
 
 /// Formats a single recipe according to a provided configuration.
@@ -47,7 +77,7 @@ fn cfg_display_recipe(recipe: &Recipe, config: &DisplayConfig) -> String {
     let subs = HashMap::from([
         (
             "name".to_string(),
-            cfg_display_recipe_name(&recipe.name, &config.name_fmt, config.name_bold),
+            cfg_display_recipe_name(recipe, &config.name_fmt, config.name_bold),
         ),
         (
             "langs".to_string(),
@@ -74,14 +104,23 @@ fn replace(subs: HashMap<String, String>, fmt_string: &str) -> String {
 }
 
 /// Displays the recipe name as configured.
-fn cfg_display_recipe_name(name: &str, fmt_string: &str, bold: bool) -> String {
-    let name_fmt = if bold {
-        name.to_string().bold().to_string()
-    } else {
-        name.to_string()
+fn cfg_display_recipe_name(recipe: &Recipe, fmt_string: &str, bold: bool) -> String {
+    let do_cond_fmt = |name: &str| {
+        if bold {
+            name.bold().to_string()
+        } else {
+            name.to_string()
+        }
     };
 
-    let subs = HashMap::from([("name".to_string(), name_fmt)]);
+    let subs = HashMap::from([
+        ("name".to_string(), do_cond_fmt(&recipe.name)),
+        ("shortname".to_string(), do_cond_fmt(recipe.shortname())),
+        (
+            "namespace".to_string(),
+            do_cond_fmt(recipe.namespace().unwrap_or("Global")),
+        ),
+    ]);
     replace(subs, fmt_string)
 }
 

--- a/src/menus/editor/mod.rs
+++ b/src/menus/editor/mod.rs
@@ -43,17 +43,18 @@ use strum::IntoEnumIterator;
 pub fn editor(args: Alter, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
     // Ensure the config is loaded in memory before proceeding.
     let _config = Config::get()?;
+    let original = Recipe::pick(&user_recipes, &args.recipe)?;
 
-    let mut recipe = Recipe::pick(&user_recipes, &args.recipe)?.clone();
-    let mut recipe_altered = false;
-
-    let original_path = recipe.dwelling()?;
-    let was_external = recipe.is_external()?;
+    let original_path = original.dwelling()?;
+    let was_external = original.is_external()?;
     let external_msg = format!(
         "{} – {}?",
-        t!("recipes.external", name => &recipe.name),
+        t!("recipes.external", name => &original.name),
         t!("general.proceed")
     );
+
+    let mut recipe = original.clone();
+    let mut recipe_altered = false;
 
     loop {
         // Target field/action,

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -65,6 +65,7 @@ pub fn evoke(recipes: &HashMap<String, Recipe>) -> Result<Vec<&Recipe>, Error> {
 
     Ok(selection
         .into_iter()
+        // This use of .get is fine since we're using a list of fully qualified recipe names.
         .map(|k| recipes.get(&k).unwrap())
         .collect())
 }

--- a/src/mkdev_error.rs
+++ b/src/mkdev_error.rs
@@ -31,6 +31,12 @@ pub enum Error {
         examples: Option<Vec<String>>,
     },
 
+    /// Occurs when a recipe query does not uniquely identify a recipe.
+    AmbiguousShortRecipe {
+        query: String,
+        possibilities: Vec<String>,
+    },
+
     /// Indicates that an action would be destructive.
     DestructionWarning { name: String },
 
@@ -89,6 +95,13 @@ impl std::fmt::Display for Error {
                         write!(f, "{base}")
                     }
                 }
+            }
+            Error::AmbiguousShortRecipe {
+                query,
+                possibilities,
+            } => {
+                let ps = possibilities.join(", ");
+                write!(f, "{} '{query}' ({ps})", t!("errors.ambiguous"))
             }
             Error::Exclude { cause } => {
                 write!(f, "{}: {cause}", t!("errors.exclude"))

--- a/src/recipe/delete.rs
+++ b/src/recipe/delete.rs
@@ -30,6 +30,9 @@ use rust_i18n::t;
 
 /// Deletes a recipe based on command line arguments.
 pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
+    if args.namespace {
+        return delete_namespace(&user_recipes, &args.recipe);
+    }
     let to_delete = Recipe::pick(&user_recipes, &args.recipe)?;
     let deleted_file = to_delete.delete()?;
 
@@ -39,6 +42,23 @@ pub fn delete_recipe(args: Delete, user_recipes: HashMap<String, Recipe>) -> Res
     );
 
     Ok(())
+}
+
+/// Deletes every recipe in a namespace.
+fn delete_namespace(user_recipes: &HashMap<String, Recipe>, name: &str) -> Result<(), Error> {
+    user_recipes
+        .values()
+        .filter(|&r| r.namespace().is_some() && r.namespace().unwrap() == name)
+        .try_for_each(|r| {
+            let deleted_file = r.delete()?;
+
+            println!(
+                "{}",
+                t!("recipes.delete_msg", path => &deleted_file.display())
+            );
+
+            Ok(())
+        })
 }
 
 impl Recipe {

--- a/src/recipe/evoke.rs
+++ b/src/recipe/evoke.rs
@@ -40,20 +40,14 @@ use rust_i18n::t;
 
 /// Evokes a recipe according to arguments from the command line.
 pub fn build_recipes(args: Evoke, user_recipes: HashMap<String, Recipe>) -> Result<(), Error> {
-    // Make sure that the recipes past are valid.
-    validate_args(&args, &user_recipes)?;
-
+    // Get the desire recipes from the cli or interactively.
     let recipes = if !args.interactive {
-        Vec::from_iter(
-            args.recipes
-                .iter()
-                .map(|r| user_recipes.get(r).expect("validated above")),
-        )
+        validate_args(&args, &user_recipes)?
     } else {
         menus::evoke(&user_recipes)?
     };
 
-    // Build to the cwd, or a directory specified by the user
+    // Build to the cwd, or a target directory if specified.
     let dir = match &args.dir_name {
         Some(dir) => PathBuf::from(dir),
         None => fs_wrappers::current_dir()?,
@@ -125,18 +119,21 @@ fn run_shell(cmd: &str) -> Option<String> {
 }
 
 /// Verifies that at least one valid recipes was passed at the command line.
-fn validate_args(args: &Evoke, user_recipes: &HashMap<String, Recipe>) -> Result<(), Error> {
+fn validate_args<'recipes>(
+    args: &Evoke,
+    user_recipes: &'recipes HashMap<String, Recipe>,
+) -> Result<Vec<&'recipes Recipe>, Error> {
     // There is an error if no recipes are provided
-    if !args.interactive && args.recipes.is_empty() {
+    if args.recipes.is_empty() {
         return Err(NoneSpecified {
             subject: Subject::Recipes,
         });
     }
 
     // Validate existence of all recipes
-    _ = Recipe::pick_many(user_recipes, &args.recipes)?;
+    let out = Recipe::pick_many(user_recipes, &args.recipes)?;
 
-    Ok(())
+    Ok(out)
 }
 
 /// Sets up the replacefmt used during evocation.

--- a/src/recipe/list.rs
+++ b/src/recipe/list.rs
@@ -20,10 +20,7 @@ use super::Recipe;
 use crate::cli::List;
 use crate::config::Config;
 use crate::display::{display_recipes_with_config, repr_tree};
-use crate::mkdev_error::{
-    Error::{self, *},
-    Subject,
-};
+use crate::mkdev_error::Error;
 use crate::output_type::OutputType::{self, *};
 
 use std::collections::HashMap;
@@ -37,12 +34,7 @@ pub fn list_recipe(args: List, user_recipes: HashMap<String, Recipe>) -> Result<
 
     match args.recipe {
         Some(recipe) => {
-            let recipe = user_recipes.get(recipe.as_str()).ok_or_else(|| Invalid {
-                subject: Subject::Recipe,
-                examples: Some(vec![recipe]),
-            })?;
-
-            display_one(recipe, output_type);
+            display_one(Recipe::pick(&user_recipes, &recipe)?, output_type);
         }
         None => {
             let mut recipes: Vec<_> = user_recipes.values().collect();

--- a/src/recipe/list.rs
+++ b/src/recipe/list.rs
@@ -38,7 +38,7 @@ pub fn list_recipe(args: List, user_recipes: HashMap<String, Recipe>) -> Result<
         }
         None => {
             let mut recipes: Vec<_> = user_recipes.values().collect();
-            recipes.sort_by(|a, b| a.name.cmp(&b.name));
+            recipes.sort_by_key(|&r| (r.namespace().is_some(), r.shortname()));
 
             display_all(recipes, output_type, !args.no_description);
         }

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -123,6 +123,10 @@ impl Recipe {
             return Ok(exact);
         }
 
+        if let Some(ns_default) = map.get(&format!("{name}::default")) {
+            return Ok(ns_default);
+        }
+
         let potential_matches: Vec<_> = map.values().filter(|r| r.shortname() == name).collect();
 
         if potential_matches.len() > 1 {

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -61,6 +61,22 @@ pub struct Recipe {
 }
 
 impl Recipe {
+    /// Get the recipe's short name with no namespace component.
+    pub fn shortname(&self) -> &str {
+        self.name
+            .rsplit_once("::")
+            .map(|(_, sn)| sn)
+            .unwrap_or(&self.name)
+    }
+
+    /// Get the recipe's namespace.
+    ///
+    /// Returns `Some(namespace)` if it belongs to a named namespace, or `None` if it belongs to the
+    /// global namespace.
+    pub fn namespace(&self) -> Option<&str> {
+        self.name.rsplit_once("::").map(|(ns, _)| ns)
+    }
+
     /// Gathers all recipes from the user directory.
     ///
     /// Only files with the .toml extension are checked. An invalid recipe gives a warning.
@@ -97,15 +113,35 @@ impl Recipe {
 
     /// Validates and returns a reference to one recipe in a map of many.
     ///
-    /// Returns `Error::Invalid` if there is no such recipe.
+    /// Returns `Error::Invalid` if there is no such recipe, or `Error::AmbiguousShortRecipe` if
+    /// multiple recipes match the query.
     pub fn pick<'recipes>(
         map: &'recipes HashMap<String, Recipe>,
         name: &str,
     ) -> Result<&'recipes Recipe, Error> {
-        map.get(name).ok_or_else(|| Error::Invalid {
-            subject: Subject::Recipe,
-            examples: Some(vec![name.into()]),
-        })
+        if let Some(exact) = map.get(name) {
+            return Ok(exact);
+        }
+
+        let potential_matches: Vec<_> = map.values().filter(|r| r.shortname() == name).collect();
+
+        if potential_matches.len() > 1 {
+            return Err(Error::AmbiguousShortRecipe {
+                query: name.to_string(),
+                possibilities: potential_matches
+                    .into_iter()
+                    .map(|r| r.name.clone())
+                    .collect(),
+            });
+        }
+
+        potential_matches
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::Invalid {
+                subject: Subject::Recipe,
+                examples: Some(vec![name.into()]),
+            })
     }
 
     /// Validates and returns a list of reference to several recipes from a map of them.
@@ -118,30 +154,27 @@ impl Recipe {
     where
         S: AsRef<str>,
     {
-        let fake_recipes: Vec<&str> = names
-            .iter()
-            .map(|s| s.as_ref())
-            .filter(|n| !map.contains_key(*n))
-            .collect();
+        let mut out = Vec::with_capacity(names.len());
+        let mut invalid = Vec::new();
 
-        if !fake_recipes.is_empty() {
-            let count = fake_recipes.len();
+        for name in names {
+            match Self::pick(map, name.as_ref()) {
+                Ok(r) => out.push(r),
+                Err(Error::Invalid { .. }) => {
+                    invalid.push(name.as_ref().to_string());
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        if !invalid.is_empty() {
             return Err(Error::Invalid {
-                subject: Subject::from_count(count),
-                examples: Some(
-                    fake_recipes
-                        .into_iter()
-                        .map(|name| name.to_string())
-                        .collect(),
-                ),
+                subject: Subject::from_count(invalid.len()),
+                examples: Some(invalid),
             });
         }
 
-        Ok(names
-            .iter()
-            .map(|s| s.as_ref())
-            .map(|name| map.get(name).unwrap())
-            .collect())
+        Ok(out)
     }
 
     /// Replaces a specific item in a recipe with a new one.


### PR DESCRIPTION
Adds the concept of recipe namespaces, groups of recipes.

*Overview*
Recipes prefixed with a pattern like `<IDENTIFIER>::<NAME>` are taken to belong to the namespace "IDENTIFIER", and are grouped visually with other like-grouped recipes. If no other recipe with <NAME> exists, the namespace identifier can be elided.

*Description of Behaviour*
```
# Recipe names
foo::foo
bar::foo
bar::baz

# Query  -> Result
foo::foo -> foo::foo
bar::foo -> bar::foo
foo      -> ERROR (ambiguous) (unless foo::default exists)
bar::baz -> bar::baz
baz      -> bar::baz
qux      -> ERROR (doesn't exist) (unless qux::default exists)
```

The exact order of resolution is as follows:
- An exact match (i.e., a recipe with the exact same name as the query exists)
- A namespace matching the query exists, and it has a default recipe
- A single recipe exists with the query as its shortname
- More than one recipe with that shortname exists (Error: ambiguous)
- No such recipe exists (Error: invalid)

*Changes*
- Update `Recipe::{pick,pick_many}` to account for this logic
- Change `DisplayConfig` and `display_recipes_with_config` to visually distinguish these namespaces
- Add functionality to `delete` subcommand to remove all recipes in a namespace (and by extension the namespace itself)

*Fixes*
- Add missing serde default for `DisplayConfig`
